### PR TITLE
Extend RVC to RVC&ZCA.

### DIFF
--- a/gcc/config/riscv/riscv-c.cc
+++ b/gcc/config/riscv/riscv-c.cc
@@ -38,7 +38,7 @@ riscv_cpu_cpp_builtins (cpp_reader *pfile)
 {
   builtin_define ("__riscv");
 
-  if (TARGET_RVC)
+  if (TARGET_RVC || TARGET_ZCA)
     builtin_define ("__riscv_compressed");
 
   if (TARGET_RVE)

--- a/gcc/config/riscv/riscv-shorten-memrefs.cc
+++ b/gcc/config/riscv/riscv-shorten-memrefs.cc
@@ -65,7 +65,8 @@ public:
   /* opt_pass methods: */
   virtual bool gate (function *)
     {
-      return TARGET_RVC && riscv_mshorten_memrefs && optimize > 0;
+      return (TARGET_RVC || TARGET_ZCA) 
+	      && riscv_mshorten_memrefs && optimize > 0;
     }
   virtual unsigned int execute (function *);
 

--- a/gcc/config/riscv/riscv.h
+++ b/gcc/config/riscv/riscv.h
@@ -178,7 +178,7 @@ ASM_MISA_SPEC
 #define PARM_BOUNDARY BITS_PER_WORD
 
 /* Allocation boundary (in *bits*) for the code of a function.  */
-#define FUNCTION_BOUNDARY (TARGET_RVC ? 16 : 32)
+#define FUNCTION_BOUNDARY (TARGET_RVC || TARGET_ZCA ? 16 : 32)
 
 /* The smallest supported stack boundary the calling convention supports.  */
 #define STACK_BOUNDARY \


### PR DESCRIPTION
Extend RVC with ZC extension and compress the instructions, since all ZC extension depend on ZCA, just combine RVC with ZCA.

gcc/ChangeLog:

        * config/riscv/riscv-c.cc (riscv_cpu_cpp_builtins): Mix Target.
        * config/riscv/riscv-shorten-memrefs.cc: Ditto.
        * config/riscv/riscv.cc (riscv_compressed_reg_p): Ditto.
        (riscv_rtx_costs): Ditto.
        (riscv_address_cost): Ditto.
        (riscv_first_stack_step): Ditto.
        * config/riscv/riscv.h (FUNCTION_BOUNDARY): Ditto.