### PR TITLE
CV32E40Pv2 CORE-V SIMD Update

### DIFF
--- a/gcc/config/riscv/constraints.md
+++ b/gcc/config/riscv/constraints.md
@@ -82,7 +82,6 @@
        (match_test "CONSTANT_P (op)")))
 
 ;; CORE-V Constraints
-<<<<<<< HEAD
 (define_constraint "M"
   "A 10-bit unsigned immediate for CORE-V bitmanip."
   (and (match_code "const_int")
@@ -92,7 +91,7 @@
   "A 2-bit unsigned immediate for CORE-V bitmanip."
   (and (match_code "const_int")
        (match_test "IN_RANGE (ival, 0, 3)")))
-=======
+
 (define_constraint "CV6"
   "A 6-bit signed immediate for SIMD."
   (and (match_code "const_int")
@@ -122,4 +121,3 @@
   "Shifting immediate for SIMD complex number, div operations, add and sub."
   (and (match_code "const_int")
        (match_test "ival == 3")))
->>>>>>> CV32E40Pv2 220 CORE-V SIMD Builtins Version 1

--- a/gcc/config/riscv/corev.md
+++ b/gcc/config/riscv/corev.md
@@ -765,7 +765,6 @@
   "cv.bitrev\t%0,%1,%2,%3"
   [(set_attr "type" "bitmanip")
   (set_attr "mode" "SI")])
-=======
 
 ;;CORE-V SIMD
 ;;CORE-V SIMD ALU

--- a/gcc/config/riscv/predicates.md
+++ b/gcc/config/riscv/predicates.md
@@ -290,6 +290,6 @@
   (ior (match_operand 0 "const_int6_operand")
        (match_operand 0 "register_operand")))
 
-(define_predicate "const_int2_operand"
+(define_predicate "const_int2_simd_operand"
   (and (match_code "const_int")
        (match_test "IN_RANGE (INTVAL (op), 0, 4)")))

--- a/gcc/doc/extend.texi
+++ b/gcc/doc/extend.texi
@@ -14633,6 +14633,7 @@ instructions, but allow the compiler to schedule those calls.
 * PowerPC Matrix-Multiply Assist Built-in Functions::
 * PRU Built-in Functions::
 * RISC-V Built-in Functions::
+* CORE-V Built-in Functions::
 * RX Built-in Functions::
 * S/390 System z Built-in Functions::
 * SH Built-in Functions::
@@ -21042,6 +21043,7 @@ processors.
 Returns the value that is currently set in the @samp{tp} register.
 @end deftypefn
 
+@node CORE-V Built-in Functions
 @subsection CORE-V Built-in Functions
 For more information on all CORE-V built-ins, please see
 @uref{https://github.com/openhwgroup/core-v-sw/blob/master/specifications/corev-builtin-spec.md}


### PR DESCRIPTION
* `gcc/config/riscv/constraints.md`: Renamed const_int2_operand to const_int2_simd_operand.
* `gcc/config/riscv/corev.md`: Renamed const_int2_operand to
const_int2_simd_operand.
* `gcc/config/riscv/predicates.md`: Changing layout of CORE-V Predicates.
* `gcc/doc/extend.texi`: Changing layout of CORE-V Built-in Documentation.