### PR TITLE
 Remove 'xcv' extension 

### DIFF
--- a/gcc/common/config/riscv/riscv-common.cc
+++ b/gcc/common/config/riscv/riscv-common.cc
@@ -212,7 +212,6 @@ static const struct riscv_ext_version riscv_ext_version_table[] =
   {"zvl32768b", ISA_SPEC_CLASS_NONE, 1, 0},
   {"zvl65536b", ISA_SPEC_CLASS_NONE, 1, 0},
 
-  {"xcv",    ISA_SPEC_CLASS_NONE, 1, 0},
   {"xcvelw", ISA_SPEC_CLASS_NONE, 1, 0},
   {"xcvmac", ISA_SPEC_CLASS_NONE, 1, 0},
   {"xcvbitmanip", ISA_SPEC_CLASS_NONE, 1, 0},
@@ -1233,7 +1232,6 @@ static const riscv_ext_flag_table_t riscv_ext_flag_table[] =
   {"zvl32768b", &gcc_options::x_riscv_zvl_flags, MASK_ZVL32768B},
   {"zvl65536b", &gcc_options::x_riscv_zvl_flags, MASK_ZVL65536B},
 
-  {"xcv",    &gcc_options::x_riscv_xcv_flags, MASK_XCV},
   {"xcvelw", &gcc_options::x_riscv_xcv_flags, MASK_XCVELW},
   {"xcvmac", &gcc_options::x_riscv_xcv_flags, MASK_XCVMAC},
   {"xcvbitmanip", &gcc_options::x_riscv_xcv_flags, MASK_XCVBITMANIP},

--- a/gcc/config/riscv/riscv-opts.h
+++ b/gcc/config/riscv/riscv-opts.h
@@ -170,13 +170,11 @@ enum stack_protector_guard {
    : 32 << (__builtin_popcount (riscv_zvl_flags) - 1))
 
 
-#define MASK_XCV       (1 <<  0)
-#define MASK_XCVELW    (1 <<  1)
-#define MASK_XCVMAC    (1 <<  2)
-#define MASK_XCVBITMANIP (1 << 3)
-#define MASK_XCVSIMD   (1 <<  4)
+#define MASK_XCVELW    (1 <<  0)
+#define MASK_XCVMAC    (1 <<  1)
+#define MASK_XCVBITMANIP (1 << 2)
+#define MASK_XCVSIMD   (1 <<  3)
 
-#define TARGET_XCV       ((riscv_xcv_flags & MASK_XCV)    != 0)
 #define TARGET_XCVELW    ((riscv_xcv_flags & MASK_XCVELW) != 0)
 #define TARGET_XCVMAC    ((riscv_xcv_flags & MASK_XCVMAC) != 0)
 #define TARGET_XCVBITMANIP    ((riscv_xcv_flags & MASK_XCVBITMANIP) != 0)


### PR DESCRIPTION
The CORE-V ISA Extension Naming specification was recently updated.
One of the consequences of this is that the option previously
called 'xcorev' (but implemented as 'xcv' presently due to the
prefix change) has been removed. However, the compiler does not
presently reflect this change. This patch removes the 'xcv' march
flag option so that the compiler and the CORE-V ISA Extension Naming
specification match.

See here for CORE-V ISA Extension Naming specification:
(https://github.com/openhwgroup/core-v-sw/blob/master/specifications/corev-isa-extension-naming.md)

	* gcc/common/config/riscv/riscv-common.cc: Remove 'xcv' extension.
	* gcc/config/riscv/riscv-opts.h: Likewise.