### PR TITLE
Removed Implicit ISA info for CORE-V

### DIFF
--- a/gcc/common/config/riscv/riscv-common.cc
+++ b/gcc/common/config/riscv/riscv-common.cc
@@ -106,11 +106,6 @@ static const riscv_implied_info_t riscv_implied_info[] =
   {"zvl32768b", "zvl16384b"},
   {"zvl65536b", "zvl32768b"},
 
-  {"xcv", "xcvelw"},
-  {"xcv", "xcvmac"},
-  {"xcv", "xcvbitmanip"},
-  {"xcv", "xcvsimd"},
-
   {NULL, NULL}
 };
 


### PR DESCRIPTION
	* gcc/common/config/riscv/riscv-common.cc: Removed xcv for all sub-extensions.