### PR TITLE
Update operand order to match spec for bit manip instructions

### DIFF
--- a/gcc/config/riscv/corev.md
+++ b/gcc/config/riscv/corev.md
@@ -484,7 +484,7 @@
          UNSPEC_CV_BITMANIP_EXTRACT_INSN))]
 
   "TARGET_XCVBITMANIP && !TARGET_64BIT"
-  "cv.extract\t%0,%1,%2,%3"
+  "cv.extract\t%0,%1,%3,%2"
   [(set_attr "type" "bitmanip")
   (set_attr "mode" "SI")])
 
@@ -537,7 +537,7 @@
          UNSPEC_CV_BITMANIP_EXTRACTU_INSN))]
 
   "TARGET_XCVBITMANIP && !TARGET_64BIT"
-  "cv.extractu\t%0,%1,%2,%3"
+  "cv.extractu\t%0,%1,%3,%2"
   [(set_attr "type" "bitmanip")
   (set_attr "mode" "SI")])
 
@@ -588,7 +588,7 @@
          UNSPEC_CV_BITMANIP_INSERT_INSN))]
 
   "TARGET_XCVBITMANIP && !TARGET_64BIT"
-  "cv.insert\t%0,%1,%2,%3"
+  "cv.insert\t%0,%1,%3,%2"
   [(set_attr "type" "bitmanip")
   (set_attr "mode" "SI")])
 
@@ -642,7 +642,7 @@
          UNSPEC_CV_BITMANIP_BCLR_INSN))]
 
   "TARGET_XCVBITMANIP && !TARGET_64BIT"
-  "cv.bclr\t%0,%1,%2,%3"
+  "cv.bclr\t%0,%1,%3,%2"
   [(set_attr "type" "bitmanip")
   (set_attr "mode" "SI")])
 
@@ -692,7 +692,7 @@
          UNSPEC_CV_BITMANIP_BSET_INSN))]
 
   "TARGET_XCVBITMANIP && !TARGET_64BIT"
-  "cv.bset\t%0,%1,%2,%3"
+  "cv.bset\t%0,%1,%3,%2"
   [(set_attr "type" "bitmanip")
   (set_attr "mode" "SI")])
 

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-compile-bclr.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-compile-bclr.c
@@ -21,8 +21,7 @@ foo (uint32_t a)
   return res1 + res2 + res3 + res4;
 }
 
-/* { dg-final { scan-assembler-times "cv\.bclr\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),6,8" 1 } } */
+/* { dg-final { scan-assembler-times "cv\.bclr\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),8,6" 1 } } */
 /* { dg-final { scan-assembler-times "cv\.bclr\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),0,0" 1 } } */
-/* { dg-final { scan-assembler-times "cv\.bclr\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),0,31" 1 } } */
+/* { dg-final { scan-assembler-times "cv\.bclr\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),31,0" 1 } } */
 /* { dg-final { scan-assembler-times "cv\.bclr\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),31,31" 1 } } */
-

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-compile-bset.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-compile-bset.c
@@ -21,7 +21,7 @@ foo (uint32_t a)
   return res1 + res2 + res3 + res4;
 }
 
-/* { dg-final { scan-assembler-times "cv\.bset\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),6,8" 1 } } */
+/* { dg-final { scan-assembler-times "cv\.bset\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),8,6" 1 } } */
 /* { dg-final { scan-assembler-times "cv\.bset\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),0,0" 1 } } */
-/* { dg-final { scan-assembler-times "cv\.bset\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),0,31" 1 } } */
+/* { dg-final { scan-assembler-times "cv\.bset\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),31,0" 1 } } */
 /* { dg-final { scan-assembler-times "cv\.bset\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),31,31" 1 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-compile-extract.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-compile-extract.c
@@ -21,7 +21,7 @@ foo (int32_t a)
   return res1 + res2 + res3 + res4;
 }
 
-/* { dg-final { scan-assembler-times "cv\.extract\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),6,8" 1 } } */
+/* { dg-final { scan-assembler-times "cv\.extract\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),8,6" 1 } } */
 /* { dg-final { scan-assembler-times "cv\.extract\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),0,0" 1 } } */
-/* { dg-final { scan-assembler-times "cv\.extract\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),0,31" 1 } } */
+/* { dg-final { scan-assembler-times "cv\.extract\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),31,0" 1 } } */
 /* { dg-final { scan-assembler-times "cv\.extract\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),31,31" 1 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-compile-extractu.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-compile-extractu.c
@@ -21,7 +21,7 @@ foo (uint32_t a)
   return res1 + res2 + res3 + res4;
 }
 
-/* { dg-final { scan-assembler-times "cv\.extractu\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),6,8" 1 } } */
+/* { dg-final { scan-assembler-times "cv\.extractu\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),8,6" 1 } } */
 /* { dg-final { scan-assembler-times "cv\.extractu\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),0,0" 1 } } */
-/* { dg-final { scan-assembler-times "cv\.extractu\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),0,31" 1 } } */
+/* { dg-final { scan-assembler-times "cv\.extractu\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),31,0" 1 } } */
 /* { dg-final { scan-assembler-times "cv\.extractu\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),31,31" 1 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-compile-insert.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-compile-insert.c
@@ -19,6 +19,6 @@ foo (uint32_t a, uint32_t b)
   return res1 + res2 + res3;
 }
 
-/* { dg-final { scan-assembler-times "cv\.insert\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),6,8" 1 } } */
+/* { dg-final { scan-assembler-times "cv\.insert\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),8,6" 1 } } */
 /* { dg-final { scan-assembler-times "cv\.insert\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),0,0" 1 } } */
-/* { dg-final { scan-assembler-times "cv\.insert\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),0,31" 1 } } */
+/* { dg-final { scan-assembler-times "cv\.insert\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),31,0" 1 } } */


### PR DESCRIPTION
Fix to issue #32.

gcc/config/riscv:
  * corev.md: Changed operand order from rd,rs1,Is3,Is2 to rd,rs1,Is2,Is3 for cv.bset, cv.bclr, cv.insert, cv.extractu, and cv.extract. This now matches the specification.

gcc/testsuite/gcc.target/riscv:
  * cv-march-xcvbitmanip-compile-bclr.c: Updated test to match spec.
  * cv-march-xcvbitmanip-compile-bset.c: Likewise.
  * cv-march-xcvbitmanip-compile-extract.c: Likewise.
  * cv-march-xcvbitmanip-compile-extractu.c: Likewise.
  * cv-march-xcvbitmanip-compile-insert.c: Likewise.

==Results==

| Category             | Previous | With commit | Delta |
| -------------------: | -------: | ----------: | ----: |
| Expected passes      |     10725 |        10725 |     - |
| Unexpected failures  |       53 |          53 |     - | 
| Unexpected successes |        - |           - |     - | 
| Expected failures    |        6 |           6 |     - | 
| Unresolved testcases |        6 |           6 |     - | 
| Unsupported tests    |      245 |         245 |     - |