### PR TITLE
CV32E40Pv2 Immediate Branch Auto-Generation Support

### DIFF
--- a/gcc/common/config/riscv/riscv-common.cc
+++ b/gcc/common/config/riscv/riscv-common.cc
@@ -1287,6 +1287,7 @@ static const riscv_ext_flag_table_t riscv_ext_flag_table[] =
   {"xcvbitmanip", &gcc_options::x_riscv_xcv_flags, MASK_XCVBITMANIP},
   {"xcvsimd", &gcc_options::x_riscv_xcv_flags, MASK_XCVSIMD},
   {"xcvalu", &gcc_options::x_riscv_xcv_flags, MASK_XCVALU},
+  {"xcvbi", &gcc_options::x_riscv_xcv_flags, MASK_XCVBI},
 
   {NULL, NULL, 0}
 };

--- a/gcc/config/riscv/constraints.md
+++ b/gcc/config/riscv/constraints.md
@@ -314,6 +314,12 @@
   (and (match_code "const_int")
        (match_test "ival == 0")))
 
+(define_constraint "BI5"
+  "A 5-bit signed immediate for Immediate Branch."
+  (and (match_code "const_int")
+       (match_test "IN_RANGE (ival, -16, 15)")))
+
+
 ;; Vector constraints.
 
 (define_register_constraint "vr" "TARGET_VECTOR ? V_REGS : NO_REGS"

--- a/gcc/config/riscv/corev.md
+++ b/gcc/config/riscv/corev.md
@@ -2825,3 +2825,17 @@
 
   [(set_attr "type" "arith")
   (set_attr "mode" "SI")])
+
+;;CORE-V Immediate Branching
+(define_insn "cv_branch<mode>"
+  [(set (pc)
+	(if_then_else
+	 (match_operator 1 "equality_operator"
+			 [(match_operand:X 2 "register_operand" "r")
+			  (match_operand:X 3 "const_int5s_operand" "BI5")])
+	 (label_ref (match_operand 0 "" ""))
+	 (pc)))]
+  "TARGET_XCVBI"
+  "cv.b%C1imm\t%2,%3,%0"
+  [(set_attr "type" "branch")
+   (set_attr "mode" "none")])

--- a/gcc/config/riscv/predicates.md
+++ b/gcc/config/riscv/predicates.md
@@ -305,6 +305,11 @@
   (ior (match_operand 0 "register_operand")
        (match_code "const_int")))
 
+(define_predicate "const_int5s_operand"
+  (and (match_code "const_int")
+       (match_test "IN_RANGE (INTVAL (op), -16, 15)")))
+
+
 ;; Predicates for the V extension.
 (define_special_predicate "vector_length_operand"
   (ior (match_operand 0 "pmode_register_operand")

--- a/gcc/config/riscv/riscv-opts.h
+++ b/gcc/config/riscv/riscv-opts.h
@@ -206,16 +206,18 @@ enum stack_protector_guard {
    : 32 << (__builtin_popcount (riscv_zvl_flags) - 1))
 
 
-#define MASK_XCVELW    (1 <<  0)
-#define MASK_XCVMAC    (1 <<  1)
-#define MASK_XCVBITMANIP (1 << 2)
-#define MASK_XCVSIMD   (1 <<  3)
-#define MASK_XCVALU    (1 <<  4)
+#define MASK_XCVELW             (1 <<  0)
+#define MASK_XCVMAC             (1 <<  1)
+#define MASK_XCVBITMANIP        (1 <<  2)
+#define MASK_XCVSIMD            (1 <<  3)
+#define MASK_XCVALU             (1 <<  4)
+#define MASK_XCVBI              (1 <<  5)
 
-#define TARGET_XCVELW    ((riscv_xcv_flags & MASK_XCVELW) != 0)
-#define TARGET_XCVMAC    ((riscv_xcv_flags & MASK_XCVMAC) != 0)
-#define TARGET_XCVBITMANIP    ((riscv_xcv_flags & MASK_XCVBITMANIP) != 0)
-#define TARGET_XCVSIMD    ((riscv_xcv_flags & MASK_XCVSIMD) != 0)
-#define TARGET_XCVALU     ((riscv_xcv_flags & MASK_XCVALU) != 0)
+#define TARGET_XCVELW           ((riscv_xcv_flags & MASK_XCVELW) != 0)
+#define TARGET_XCVMAC           ((riscv_xcv_flags & MASK_XCVMAC) != 0)
+#define TARGET_XCVBITMANIP      ((riscv_xcv_flags & MASK_XCVBITMANIP) != 0)
+#define TARGET_XCVSIMD          ((riscv_xcv_flags & MASK_XCVSIMD) != 0)
+#define TARGET_XCVALU           ((riscv_xcv_flags & MASK_XCVALU) != 0)
+#define TARGET_XCVBI            ((riscv_xcv_flags & MASK_XCVBI) != 0)
 
 #endif /* ! GCC_RISCV_OPTS_H */

--- a/gcc/config/riscv/riscv.md
+++ b/gcc/config/riscv/riscv.md
@@ -442,6 +442,14 @@
 (define_asm_attributes
   [(set_attr "type" "multi")])
 
+;; ..............................
+;;
+;;	Machine Description Patterns
+;;
+;; ..............................
+
+(include "corev.md")
+
 ;; Ghost instructions produce no real code and introduce no hazards.
 ;; They exist purely to express an effect on dataflow.
 (define_insn_reservation "ghost" 0
@@ -3108,4 +3116,3 @@
 (include "generic.md")
 (include "sifive-7.md")
 (include "vector.md")
-(include "corev.md")

--- a/gcc/testsuite/gcc.target/riscv/cv-bi-beqimm-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-bi-beqimm-compile-1.c
@@ -1,0 +1,15 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv32i_xcvbi1p0 -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* }  { "-O0" } { "" } } */
+
+/* __builtin_expect is used to provide the compiler with
+   branch prediction information and to direct the compiler
+   to the expected flow through the code.  */
+
+int foo1(int a, int x, int y)
+{
+    a = __builtin_expect(a, 12);
+    return a != 10 ? x : y;
+}
+
+/* { dg-final { scan-assembler-times "cv\\.beqimm\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),10,\(\?\:.L\[0-9\]\)" 1 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-bi-beqimm-compile-2.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-bi-beqimm-compile-2.c
@@ -1,0 +1,42 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv32i_xcvbi1p0 -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* }  { "-O0" } { "" } } */
+
+/* __builtin_expect is used to provide the compiler with
+   branch prediction information and to direct the compiler
+   to the expected flow through the code.  */
+
+int foo1(int a, int x, int y)
+{
+    a = __builtin_expect(a, 10);
+    return a != -16 ? x : y;
+}
+
+int foo2(int a, int x, int y)
+{
+    a = __builtin_expect(a, 10);
+    return a != 0 ? x : y;
+}
+
+int foo3(int a, int x, int y)
+{
+    a = __builtin_expect(a, 10);
+    return a != 15 ? x : y;
+}
+
+int foo4(int a, int x, int y)
+{
+    a = __builtin_expect(a, 10);
+    return a != -17 ? x : y;
+}
+
+int foo5(int a, int x, int y)
+{
+    a = __builtin_expect(a, 10);
+    return a != 16 ? x : y;
+}
+
+/* { dg-final { scan-assembler-times "cv\\.beqimm\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),-16,\(\?\:.L\[0-9\]\)" 1 } } */
+/* { dg-final { scan-assembler-times "cv\\.beqimm\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),0,\(\?\:.L\[0-9\]\)" 1 } } */
+/* { dg-final { scan-assembler-times "cv\\.beqimm\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),15,\(\?\:.L\[0-9\]\)" 1 } } */
+/* { dg-final { scan-assembler-times "beq\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:.L\[0-9\]+\)" 2 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-bi-bneimm-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-bi-bneimm-compile-1.c
@@ -1,0 +1,15 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv32i_xcvbi1p0 -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* }  { "-O0" } { "" } } */
+
+/* __builtin_expect is used to provide the compiler with
+   branch prediction information and to direct the compiler
+   to the expected flow through the code.  */
+
+int foo1(int a, int x, int y)
+{
+    a = __builtin_expect(a, 10);
+    return a == 10 ? x : y;
+}
+
+/* { dg-final { scan-assembler-times "cv\\.bneimm\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),10,\(\?\:.L\[0-9\]\)" 1 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-bi-bneimm-compile-2.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-bi-bneimm-compile-2.c
@@ -1,0 +1,42 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv32i_xcvbi1p0 -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* }  { "-O0" } { "" } } */
+
+/* __builtin_expect is used to provide the compiler with
+   branch prediction information and to direct the compiler
+   to the expected flow through the code.  */
+
+int foo1(int a, int x, int y)
+{
+    a = __builtin_expect(a, -16);
+    return a == -16 ? x : y;
+}
+
+int foo2(int a, int x, int y)
+{
+    a = __builtin_expect(a, 0);
+    return a == 0 ? x : y;
+}
+
+int foo3(int a, int x, int y)
+{
+    a = __builtin_expect(a, 15);
+    return a == 15 ? x : y;
+}
+
+int foo4(int a, int x, int y)
+{
+    a = __builtin_expect(a, -17);
+    return a == -17 ? x : y;
+}
+
+int foo5(int a, int x, int y)
+{
+    a = __builtin_expect(a, 16);
+    return a == 16 ? x : y;
+}
+
+/* { dg-final { scan-assembler-times "cv\\.bneimm\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),-16,\(\?\:.L\[0-9\]\)" 1 } } */
+/* { dg-final { scan-assembler-times "cv\\.bneimm\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),0,\(\?\:.L\[0-9\]\)" 1 } } */
+/* { dg-final { scan-assembler-times "cv\\.bneimm\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),15,\(\?\:.L\[0-9\]\)" 1 } } */
+/* { dg-final { scan-assembler-times "bne\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:.L\[0-9\]+\)" 2 } } */


### PR DESCRIPTION
* `gcc/common/config/riscv/riscv-common.cc`: Created `XCVBI` extension support.
* `gcc/config/riscv/riscv-opts.h`: Created MASK and TARGET macros for `XCVBI`.
* `gcc/config/riscv/corev.md`: Implemented `cv_branch<mode>` pattern for `cv.beqimm` and `cv.bneimm`.
* `gcc/config/riscv/riscv.md`: Changed pattern priority so `corev.md` patterns run before `riscv.md` patterns.
* `gcc/config/riscv/constraints.md`: Implemented constraints `BI5` - signed 5-bit immediate.
* `gcc/config/riscv/predicates.md`: Implemented predicate `const_int5s_operand` - signed 5 bit immediate.
* `gcc/testsuite/gcc.target/riscv/cv-bi-beqimm-compile-1.c`: Testing auto-generation for instruction `cv.beqimm` at all optimisation levels.
* `gcc/testsuite/gcc.target/riscv/cv-bi-beqimm-compile-2.c`: Boundary testing for instruction `cv.beqimm` at all optimisation levels.
* `gcc/testsuite/gcc.target/riscv/cv-bi-bneimm-compile-1.c`: Testing auto-generation for instruction `cv.bneimm` at all optimisation levels.
* `gcc/testsuite/gcc.target/riscv/cv-bi-bneimm-compile-2.c`: Boundary testing for instruction `cv.bneimm` at all optimisation levels.