### PR TITLE
Autogenerate for mac and msu builtins

### DIFF
--- a/gcc/config/riscv/corev.md
+++ b/gcc/config/riscv/corev.md
@@ -230,9 +230,9 @@
 
 (define_insn "riscv_cv_mac_mac"
   [(set (match_operand:SI 0 "register_operand" "=r")
-        (fma:SI (match_operand:SI 1 "register_operand" "r")
-                (match_operand:SI 2 "register_operand" "r")
-                (match_operand:SI 3 "register_operand" "0")))]
+        (plus:SI (mult:SI (match_operand:SI 1 "register_operand" "r")
+                		 (match_operand:SI 2 "register_operand" "r"))
+						 (match_operand:SI 3 "register_operand" "0")))]
 
   "TARGET_XCVMAC && !TARGET_64BIT"
   "cv.mac\t%0,%1,%2"

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-test-autogeneration-mac.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-test-autogeneration-mac.c
@@ -1,0 +1,10 @@
+/* { dg-do compile } */
+/* { dg-options "-02 -march=rv32im_xcvmac1p0 -mabi=ilp32" } */
+
+int foo(int a, int b, int c)
+{
+    return a * b + c;
+}
+
+/* { dg-final { scan-assembler-times "cv\\.mac" 1 } } */
+

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-test-autogeneration-msu.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-test-autogeneration-msu.c
@@ -1,0 +1,10 @@
+/* { dg-do compile } */
+/* { dg-options "-02 -march=rv32im_xcvmac1p0 -mabi=ilp32" } */
+
+int foo(int a, int b, int c)
+{
+    return a - b * c;
+}
+
+/* { dg-final { scan-assembler-times "cv\\.msu" 1 } } */
+


### PR DESCRIPTION
Files changed:
* gcc/config/riscv/corev.md: update the builtins patterns.
* gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-test-autogeneration-mac.c: test for autogeneration.
* gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-test-autogeneration-msu.c: Likewise.