### PR TITLE
CORE-V: Support CORE-V fast interrupts

### DIFF
--- a/gcc/config/riscv/riscv.cc
+++ b/gcc/config/riscv/riscv.cc
@@ -141,7 +141,15 @@ enum riscv_privilege_levels {
   UNKNOWN_MODE, USER_MODE, SUPERVISOR_MODE, MACHINE_MODE
 };
 
-struct GTY(())  machine_function {
+struct GTY(()) riscv_interrupt_type {
+  /* The privilege mode for this interrupt.  */
+  enum riscv_privilege_levels mode;
+  /* Whether the interrupt function is responsible for saving call used
+     registers.  */
+  bool save_call_used_p;
+};
+
+struct GTY(()) machine_function {
   /* The number of extra stack bytes taken up by register varargs.
      This area is allocated by the callee at the very top of the frame.  */
   int varargs_size;
@@ -151,8 +159,9 @@ struct GTY(())  machine_function {
 
   /* True if current function is an interrupt function.  */
   bool interrupt_handler_p;
-  /* For an interrupt handler, indicates the privilege level.  */
-  enum riscv_privilege_levels interrupt_mode;
+
+  /* For an interrupt handler, indicates the type of interrupt.  */
+  struct riscv_interrupt_type interrupt_type;
 
   /* True if attributes on current function have been checked.  */
   bool attributes_checked_p;
@@ -384,7 +393,7 @@ static const struct attribute_spec riscv_attribute_table[] =
   { "naked",	0,  0, true, false, false, false,
     riscv_handle_fndecl_attribute, NULL },
   /* This attribute generates prologue/epilogue for interrupt handlers.  */
-  { "interrupt", 0, 1, false, true, true, false,
+  { "interrupt", 0, 2, false, true, true, false,
     riscv_handle_type_attribute, NULL },
 
   /* The following two are used for the built-in properties of the Vector type
@@ -3914,29 +3923,59 @@ riscv_handle_type_attribute (tree *node ATTRIBUTE_UNUSED, tree name, tree args,
   /* Check for an argument.  */
   if (is_attribute_p ("interrupt", name))
     {
-      if (args)
+      int narg = 0;
+      while (args)
 	{
+	  narg++;
 	  tree cst = TREE_VALUE (args);
 	  const char *string;
 
 	  if (TREE_CODE (cst) != STRING_CST)
 	    {
 	      warning (OPT_Wattributes,
-		       "%qE attribute requires a string argument",
-		       name);
+		       "%qE attribute argument %d is not a string",
+		       name, narg);
 	      *no_add_attrs = true;
 	      return NULL_TREE;
 	    }
 
 	  string = TREE_STRING_POINTER (cst);
+
+	  /* Optional "corev-fast" argument.  If given, must be first argument.
+	  */
+	  if (narg == 1 && !(strcmp (string, "corev-fast")))
+	    {
+	      args = TREE_CHAIN (args);
+	      continue;
+	    }
+
+	  /* Optional mode argument.  */
 	  if (strcmp (string, "user") && strcmp (string, "supervisor")
 	      && strcmp (string, "machine"))
 	    {
+	      if (narg == 1)
+		warning (OPT_Wattributes,
+			 "%qE attribute argument %d is not a type "
+			 "(%<\"corev-fast\"%>) or mode (%<\"user\"%>, "
+			 "%<\"supervisor\"%>, or %<\"machine\"%>)", name, narg);
+	      else
+		warning (OPT_Wattributes,
+			 "%qE attribute argument %d is not %<\"user\"%>, "
+			 "%<\"supervisor\"%>, or %<\"machine\"%>", name, narg);
+
+	      *no_add_attrs = true;
+	      return NULL_TREE;
+	    }
+	  /* There should be no more arguments after the mode argument.  */
+	  else if (TREE_CHAIN (args))
+	    {
 	      warning (OPT_Wattributes,
-		       "argument to %qE attribute is not %<\"user\"%>, %<\"supervisor\"%>, "
-		       "or %<\"machine\"%>", name);
+		       "unexpected argument to %qE attribute after mode argument",
+		       name);
 	      *no_add_attrs = true;
 	    }
+
+	  return NULL_TREE;
 	}
     }
 
@@ -4715,6 +4754,11 @@ riscv_save_reg_p (unsigned int regno)
   bool might_clobber = crtl->saves_all_registers
 		       || df_regs_ever_live_p (regno);
 
+  /* This type of interrupt does not need to save return address.  */
+  if (regno == RETURN_ADDR_REGNUM && cfun->machine->interrupt_handler_p
+      && !cfun->machine->interrupt_type.save_call_used_p)
+    return false;
+
   if (call_saved && might_clobber)
     return true;
 
@@ -4737,6 +4781,12 @@ riscv_save_reg_p (unsigned int regno)
 
       /* By convention, we assume that gp and tp are safe.  */
       if (regno == GP_REGNUM || regno == THREAD_POINTER_REGNUM)
+	return false;
+
+      /* This type of interrupt does not need to save call used registers,
+	 possibly because the hardware saves them instead.  */
+      if (call_used_or_fixed_reg_p (regno)
+	  && !cfun->machine->interrupt_type.save_call_used_p)
 	return false;
 
       /* We must save every register used in this function.  If this is not a
@@ -4900,7 +4950,8 @@ riscv_compute_frame_info (void)
 
   /* In an interrupt function, if we have a large frame, then we need to
      save/restore t0.  We check for this before clearing the frame struct.  */
-  if (cfun->machine->interrupt_handler_p)
+  if (cfun->machine->interrupt_handler_p
+      && cfun->machine->interrupt_type.save_call_used_p)
     {
       HOST_WIDE_INT step1 = riscv_first_stack_step (frame);
       if (! POLY_SMALL_OPERAND_P ((frame->total_size - step1)))
@@ -5852,7 +5903,7 @@ riscv_expand_epilogue (int style)
   /* Return from interrupt.  */
   if (cfun->machine->interrupt_handler_p)
     {
-      enum riscv_privilege_levels mode = cfun->machine->interrupt_mode;
+      enum riscv_privilege_levels mode = cfun->machine->interrupt_type.mode;
 
       gcc_assert (mode != UNKNOWN_MODE);
 
@@ -5877,6 +5928,10 @@ riscv_epilogue_uses (unsigned int regno)
 
   if (epilogue_completed && cfun->machine->interrupt_handler_p)
     {
+      if (!cfun->machine->interrupt_type.save_call_used_p
+	  && call_used_or_fixed_reg_p (regno))
+	return false;
+
       /* An interrupt function restores temp regs, so we must indicate that
 	 they are live at function end.  */
       if (df_regs_ever_live_p (regno)
@@ -6844,16 +6899,19 @@ riscv_function_ok_for_sibcall (tree decl ATTRIBUTE_UNUSED,
   return true;
 }
 
-/* Get the interrupt type, return UNKNOWN_MODE if it's not
+/* Get the interrupt type, return {UNKNOWN_MODE, false} if it's not
    interrupt function. */
-static enum riscv_privilege_levels
+static struct riscv_interrupt_type
 riscv_get_interrupt_type (tree decl)
 {
+  /* Interrupt functions are machine mode by default and expected to save call
+     used registers.  */
+  struct riscv_interrupt_type type = {MACHINE_MODE, true};
   gcc_assert (decl != NULL_TREE);
 
   if ((TREE_CODE(decl) != FUNCTION_DECL)
       || (!riscv_interrupt_type_p (TREE_TYPE (decl))))
-    return UNKNOWN_MODE;
+    return {UNKNOWN_MODE, false};
 
   tree attr_args
     = TREE_VALUE (lookup_attribute ("interrupt",
@@ -6863,16 +6921,26 @@ riscv_get_interrupt_type (tree decl)
     {
       const char *string = TREE_STRING_POINTER (TREE_VALUE (attr_args));
 
+      if (!(strcmp (string, "corev-fast")))
+	{
+	  /* For corev-fast interrupt functions do not need to save call used
+	     registers, instead the hardware is expected to take care of this.
+	  */
+	  type.save_call_used_p = false;
+	  attr_args = TREE_CHAIN(attr_args);
+	  if (attr_args)
+	    string = TREE_STRING_POINTER (TREE_VALUE (attr_args));
+	}
+
       if (!strcmp (string, "user"))
-	return USER_MODE;
+	type.mode = USER_MODE;
       else if (!strcmp (string, "supervisor"))
-	return SUPERVISOR_MODE;
-      else /* Must be "machine".  */
-	return MACHINE_MODE;
+	type.mode = SUPERVISOR_MODE;
+      /* Otherwise must be "machine" and type.mode was already set to
+	 MACHINE_MODE.  */
     }
-  else
-    /* Interrupt attributes are machine mode by default.  */
-    return MACHINE_MODE;
+
+  return type;
 }
 
 /* Implement `TARGET_SET_CURRENT_FUNCTION'.  */
@@ -6906,9 +6974,9 @@ riscv_set_current_function (tree decl)
       if (args && TREE_CODE (TREE_VALUE (args)) != VOID_TYPE)
 	error ("%qs function cannot have arguments", "interrupt");
 
-      cfun->machine->interrupt_mode = riscv_get_interrupt_type (decl);
+      cfun->machine->interrupt_type = riscv_get_interrupt_type (decl);
 
-      gcc_assert (cfun->machine->interrupt_mode != UNKNOWN_MODE);
+      gcc_assert (cfun->machine->interrupt_type.mode != UNKNOWN_MODE);
     }
 
   /* Don't print the above diagnostics more than once.  */
@@ -6921,15 +6989,17 @@ riscv_merge_decl_attributes (tree olddecl, tree newdecl)
 {
   tree combined_attrs;
 
-  enum riscv_privilege_levels old_interrupt_type
+  struct riscv_interrupt_type old_interrupt_type
     = riscv_get_interrupt_type (olddecl);
-  enum riscv_privilege_levels new_interrupt_type
+  struct riscv_interrupt_type new_interrupt_type
     = riscv_get_interrupt_type (newdecl);
 
   /* Check old and new has same interrupt type. */
-  if ((old_interrupt_type != UNKNOWN_MODE)
-      && (new_interrupt_type != UNKNOWN_MODE)
-      && (old_interrupt_type != new_interrupt_type))
+  if ((old_interrupt_type.mode != UNKNOWN_MODE)
+      && (new_interrupt_type.mode != UNKNOWN_MODE)
+      && ((old_interrupt_type.mode != new_interrupt_type.mode)
+	  || (old_interrupt_type.save_call_used_p
+	      != new_interrupt_type.save_call_used_p)))
     error ("%qs function cannot have different interrupt type", "interrupt");
 
   /* Create combined attributes.  */

--- a/gcc/doc/extend.texi
+++ b/gcc/doc/extend.texi
@@ -6089,20 +6089,21 @@ depended upon to work reliably and are not supported.
 
 @cindex @code{interrupt} function attribute, RISC-V
 @item interrupt
+@itemx interrupt (mode)
+@itemx interrupt ("corev-fast", mode)
 Use this attribute to indicate that the specified function is an interrupt
 handler.  The compiler generates function entry and exit sequences suitable
 for use in an interrupt handler when this attribute is present.
 
-You can specify the kind of interrupt to be handled by adding an optional
-parameter to the interrupt attribute like this:
-
-@smallexample
-void f (void) __attribute__ ((interrupt ("user")));
-@end smallexample
-
+The optional @code{mode} parameter is used to specify the mode of the interrupt.
 Permissible values for this parameter are @code{user}, @code{supervisor},
 and @code{machine}.  If there is no parameter, then it defaults to
 @code{machine}.
+
+The optional @code{"corev-fast"} parameter specifies that the function is a
+CORE-V fast interrupt handler, which behaves the same as a normal interrupt
+handler except caller saved registers (including @code{ra}) are not saved by the
+function.
 @end table
 
 @node RL78 Function Attributes

--- a/gcc/testsuite/gcc.target/riscv/cv-interrupt-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-interrupt-1.c
@@ -1,0 +1,8 @@
+/* Verify the return instruction is mret.  */
+/* { dg-do compile } */
+/* { dg-options "" } */
+void __attribute__ ((interrupt ("corev-fast")))
+foo (void)
+{
+}
+/* { dg-final { scan-assembler "mret" } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-interrupt-2.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-interrupt-2.c
@@ -1,0 +1,13 @@
+/* Verify that arg regs used as temporaries do not get saved.  */
+/* { dg-do compile } */
+/* { dg-options "" } */
+void __attribute__ ((interrupt ("corev-fast")))
+foo2 (void)
+{
+  extern volatile int INTERRUPT_FLAG;
+  INTERRUPT_FLAG = 0;
+
+  extern volatile int COUNTER;
+  COUNTER++;
+}
+/* { dg-final { scan-assembler-not "s\[wd\]\ta\[0-7\],\[0-9\]+\\(sp\\)" } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-interrupt-3.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-interrupt-3.c
@@ -1,0 +1,10 @@
+/* Verify t0 is not saved before use.  */
+/* { dg-do compile } */
+/* { dg-options "-fomit-frame-pointer" } */
+/* { dg-skip-if "" { *-*-* } { "*" } { "-O0" } } */
+void __attribute__ ((interrupt ("corev-fast")))
+foo (void)
+{
+  char array[4096];
+}
+/* { dg-final { scan-assembler-not "s\[wd\]\tt0" } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-interrupt-4.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-interrupt-4.c
@@ -1,0 +1,19 @@
+/* Verify t0 is not saved before use.  */
+/* { dg-do compile } */
+/* { dg-options "-fomit-frame-pointer" } */
+/* { dg-skip-if "" { *-*-* } { "*" } { "-O0" } } */
+void __attribute__ ((interrupt ("corev-fast")))
+foo2 (void)
+{
+  char array[4096];
+  extern volatile int INTERRUPT_FLAG;
+  INTERRUPT_FLAG = 0;
+
+  extern volatile int COUNTER;
+#ifdef __riscv_atomic
+  __atomic_fetch_add (&COUNTER, 1, __ATOMIC_RELAXED);
+#else
+  COUNTER++;
+#endif
+}
+/* { dg-final { scan-assembler-not "s\[wd\]\tt0" } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-interrupt-5.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-interrupt-5.c
@@ -1,0 +1,71 @@
+/* Verify proper errors are generated for invalid code.  */
+int __attribute__ ((interrupt ("corev-fast")))
+sub0 (void)
+{ /* { dg-error "function cannot return a value" } */
+  return 10;
+}
+
+void __attribute__ ((interrupt ("corev-fast")))
+sub1 (int i)
+{ /* { dg-error "function cannot have arguments" } */
+}
+
+void __attribute__ ((interrupt ("corev-fast"), naked))
+sub2 (void)
+{ /* { dg-error "are mutually exclusive" } */
+}
+
+void __attribute__ ((interrupt ("corev-fast", "hypervisor")))
+sub3 (void)
+{ /* { dg-warning "argument 2 is not" } */
+}
+
+void __attribute__ ((interrupt ("machine", "corev-fast")))
+sub4 (void)
+{ /* { dg-warning "unexpected argument to" } */
+}
+
+void __attribute__ ((interrupt ("supervisor", "corev-fast")))
+sub5 (void)
+{ /* { dg-warning "unexpected argument to" } */
+}
+
+void __attribute__ ((interrupt ("user", "corev-fast")))
+sub6 (void)
+{ /* { dg-warning "unexpected argument to" } */
+}
+
+void __attribute__ ((interrupt ("", "corev-fast")))
+sub7 (void)
+{ /* { dg-warning "argument 1 is not" } */
+}
+
+void __attribute__ ((interrupt ("corev-fast", "")))
+sub8 (void)
+{ /* { dg-warning "argument 2 is not" } */
+}
+
+void __attribute__ ((interrupt (7)))
+sub9 (void)
+{ /* { dg-warning "argument 1 is not" } */
+}
+
+void __attribute__ ((interrupt ("corev-fast", 8)))
+sub10 (void)
+{ /* { dg-warning "argument 2 is not" } */
+}
+
+void __attribute__ ((interrupt ("corev-fast", "machine", "user")))
+sub11 (void)
+{ /* { dg-error "wrong number of arguments" } */
+}
+
+void __attribute__ ((interrupt ("machine", "user")))
+sub12 (void)
+{ /* { dg-warning "unexpected argument to" } */
+}
+
+void __attribute__ ((interrupt ("machine", "supervisor", "user")))
+sub13 (void)
+{ /* { dg-error "wrong number of arguments" } */
+}

--- a/gcc/testsuite/gcc.target/riscv/cv-interrupt-all-f-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-interrupt-all-f-1.c
@@ -1,0 +1,78 @@
+/* Verify all F registers are saved.  */
+/* { dg-do compile } */
+/* { dg-options "-fomit-frame-pointer -march=rv32if -mabi=ilp32f" } */
+void __attribute__ ((interrupt))
+foo (void)
+{
+  asm volatile ("" : : :  "f0",  "f1",  "f2",  "f3",  "f4",  "f5",  "f6",  "f7",
+			  "f8",  "f9", "f10", "f11", "f12", "f13", "f14", "f15",
+			 "f16", "f17", "f18", "f19", "f20", "f21", "f22", "f23",
+			 "f24", "f25", "f26", "f27", "f28", "f29", "f30", "f31"
+	       );
+}
+
+/* { dg-final { scan-assembler-times "flw\[ \t\]+ft0,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+ft1,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+ft2,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+ft3,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+ft4,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+ft5,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+ft6,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+ft7,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+fs0,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+fs1,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+fa0,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+fa1,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+fa2,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+fa3,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+fa4,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+fa5,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+fa6,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+fa7,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+fs2,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+fs3,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+fs4,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+fs5,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+fs6,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+fs7,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+fs8,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+fs9,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+fs10,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+fs11,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+ft8,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+ft9,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+ft10,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+ft11,\[0-9\]+\\(sp\\)" 1 } } */
+
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+ft0,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+ft1,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+ft2,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+ft3,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+ft4,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+ft5,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+ft6,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+ft7,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+fs0,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+fs1,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+fa0,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+fa1,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+fa2,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+fa3,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+fa4,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+fa5,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+fa6,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+fa7,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+fs2,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+fs3,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+fs4,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+fs5,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+fs6,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+fs7,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+fs8,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+fs9,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+fs10,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+fs11,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+ft8,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+ft9,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+ft10,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+ft11,\[0-9\]+\\(sp\\)" 1 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-interrupt-all-f-2.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-interrupt-all-f-2.c
@@ -1,0 +1,41 @@
+/* Verify only callee saved F registers are saved.  */
+/* { dg-do compile } */
+/* { dg-options "-fomit-frame-pointer -march=rv32if -mabi=ilp32f" } */
+void __attribute__ ((interrupt ("corev-fast")))
+foo (void)
+{
+  asm volatile ("" : : :  "f0",  "f1",  "f2",  "f3",  "f4",  "f5",  "f6",  "f7",
+			  "f8",  "f9", "f10", "f11", "f12", "f13", "f14", "f15",
+			 "f16", "f17", "f18", "f19", "f20", "f21", "f22", "f23",
+			 "f24", "f25", "f26", "f27", "f28", "f29", "f30", "f31"
+	       );
+}
+
+/* { dg-final { scan-assembler-not "f\[sl\]w\[ \t\]+fa" } } */
+/* { dg-final { scan-assembler-not "f\[sl\]w\[ \t\]+ft" } } */
+
+/* { dg-final { scan-assembler-times "flw\[ \t\]+fs0,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+fs1,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+fs2,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+fs3,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+fs4,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+fs5,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+fs6,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+fs7,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+fs8,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+fs9,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+fs10,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+fs11,\[0-9\]+\\(sp\\)" 1 } } */
+
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+fs0,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+fs1,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+fs2,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+fs3,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+fs4,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+fs5,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+fs6,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+fs7,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+fs8,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+fs9,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+fs10,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+fs11,\[0-9\]+\\(sp\\)" 1 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-interrupt-all-x-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-interrupt-all-x-1.c
@@ -1,0 +1,75 @@
+/* Verify all X registers are saved except x0, sp, gp, tp.  */
+/* { dg-do compile } */
+/* { dg-options "-fomit-frame-pointer" } */
+void __attribute__ ((interrupt))
+foo (void)
+{
+  /* Clobber all registers except sp which is not allowed.  */
+  asm volatile ("" : : :  "x0",  "x1",  "x3",  "x4",  "x5",  "x6",  "x7",  "x8",
+  	                  "x9", "x10", "x11", "x12", "x13", "x14", "x15", "x16",
+  	                 "x17", "x18", "x19", "x20", "x21", "x22", "x23", "x24",
+  	                 "x25", "x26", "x27", "x28", "x29", "x30", "x31");
+}
+
+/* { dg-final { scan-assembler-not "\[sl\]w\[ \t\]+zero" } } */
+/* { dg-final { scan-assembler-not "\[sl\]w\[ \t\]+sp" } } */
+/* { dg-final { scan-assembler-not "\[sl\]w\[ \t\]+gp" } } */
+/* { dg-final { scan-assembler-not "\[sl\]w\[ \t\]+tp" } } */
+
+/* { dg-final { scan-assembler-times "lw\[ \t\]+ra,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+t0,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+t1,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+t2,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+s0,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+s1,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+a0,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+a1,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+a2,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+a3,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+a4,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+a5,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+a6,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+a7,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+s2,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+s3,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+s4,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+s5,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+s6,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+s7,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+s8,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+s9,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+s10,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+s11,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+t3,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+t4,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+t5,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+t6,\[0-9\]+\\(sp\\)" 1 } } */
+
+/* { dg-final { scan-assembler-times "sw\[ \t\]+ra,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+t0,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+t1,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+t2,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+s0,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+s1,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+a0,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+a1,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+a2,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+a3,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+a4,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+a5,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+a6,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+a7,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+s2,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+s3,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+s4,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+s5,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+s6,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+s7,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+s8,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+s9,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+s10,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+s11,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+t3,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+t4,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+t5,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+t6,\[0-9\]+\\(sp\\)" 1 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-interrupt-all-x-2.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-interrupt-all-x-2.c
@@ -1,0 +1,47 @@
+/* Verify only callee saved X registers are saved.  */
+/* { dg-do compile } */
+/* { dg-options "-fomit-frame-pointer" } */
+void __attribute__ ((interrupt ("corev-fast")))
+foo (void)
+{
+  /* Clobber all registers except sp which is not allowed.  */
+  asm volatile ("" : : :  "x0",  "x1",  "x3",  "x4",  "x5",  "x6",  "x7",  "x8",
+  	                  "x9", "x10", "x11", "x12", "x13", "x14", "x15", "x16",
+  	                 "x17", "x18", "x19", "x20", "x21", "x22", "x23", "x24",
+  	                 "x25", "x26", "x27", "x28", "x29", "x30", "x31");
+}
+
+/* { dg-final { scan-assembler-not "\[sl\]w\[ \t\]+zero" } } */
+/* { dg-final { scan-assembler-not "\[sl\]w\[ \t\]+sp" } } */
+/* { dg-final { scan-assembler-not "\[sl\]w\[ \t\]+gp" } } */
+/* { dg-final { scan-assembler-not "\[sl\]w\[ \t\]+tp" } } */
+
+/* { dg-final { scan-assembler-not "\[sl\]w\[ \t\]+ra" } } */
+/* { dg-final { scan-assembler-not "\[sl\]w\[ \t\]+a\[0-7\]" } } */
+/* { dg-final { scan-assembler-not "\[sl\]w\[ \t\]+t\[0-6\]" } } */
+
+/* { dg-final { scan-assembler-times "lw\[ \t\]+s0,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+s1,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+s2,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+s3,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+s4,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+s5,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+s6,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+s7,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+s8,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+s9,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+s10,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+s11,\[0-9\]+\\(sp\\)" 1 } } */
+
+/* { dg-final { scan-assembler-times "sw\[ \t\]+s0,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+s1,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+s2,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+s3,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+s4,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+s5,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+s6,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+s7,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+s8,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+s9,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+s10,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+s11,\[0-9\]+\\(sp\\)" 1 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-interrupt-all-x-3.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-interrupt-all-x-3.c
@@ -1,0 +1,50 @@
+/* Verify a non-leaf interrupt saves all caller saved registers except x0, sp,
+   gp, tp.  */
+/* { dg-do compile } */
+/* { dg-options "-fomit-frame-pointer" } */
+extern void bar (void);
+
+void __attribute__ ((interrupt))
+foo (void)
+{
+  bar ();
+}
+
+/* { dg-final { scan-assembler-not "\[sl\]w\[ \t\]+zero" } } */
+/* { dg-final { scan-assembler-not "\[sl\]w\[ \t\]+sp" } } */
+/* { dg-final { scan-assembler-not "\[sl\]w\[ \t\]+gp" } } */
+/* { dg-final { scan-assembler-not "\[sl\]w\[ \t\]+tp" } } */
+
+/* { dg-final { scan-assembler-times "lw\[ \t\]+ra,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+t0,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+t1,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+t2,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+a0,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+a1,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+a2,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+a3,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+a4,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+a5,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+a6,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+a7,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+t3,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+t4,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+t5,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+t6,\[0-9\]+\\(sp\\)" 1 } } */
+
+/* { dg-final { scan-assembler-times "sw\[ \t\]+ra,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+t0,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+t1,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+t2,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+a0,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+a1,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+a2,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+a3,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+a4,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+a5,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+a6,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+a7,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+t3,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+t4,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+t5,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+t6,\[0-9\]+\\(sp\\)" 1 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-interrupt-all-x-4.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-interrupt-all-x-4.c
@@ -1,0 +1,19 @@
+/* Verify a non-leaf interrupt does not save any caller saved registers.  */
+/* { dg-do compile } */
+/* { dg-options "-fomit-frame-pointer" } */
+extern void bar (void);
+
+void __attribute__ ((interrupt ("corev-fast")))
+foo (void)
+{
+  bar ();
+}
+
+/* { dg-final { scan-assembler-not "\[sl\]w\[ \t\]+zero" } } */
+/* { dg-final { scan-assembler-not "\[sl\]w\[ \t\]+sp" } } */
+/* { dg-final { scan-assembler-not "\[sl\]w\[ \t\]+gp" } } */
+/* { dg-final { scan-assembler-not "\[sl\]w\[ \t\]+tp" } } */
+
+/* { dg-final { scan-assembler-not "\[sl\]w\[ \t\]+ra" } } */
+/* { dg-final { scan-assembler-not "\[sl\]w\[ \t\]+a\[0-7\]" } } */
+/* { dg-final { scan-assembler-not "\[sl\]w\[ \t\]+t\[0-6\]" } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-interrupt-conflict-type.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-interrupt-conflict-type.c
@@ -1,0 +1,18 @@
+/* Verify proper errors are generated for conflicting interrupt type.  */
+/* { dg-do compile } */
+/* { dg-options "" } */
+void __attribute__ ((interrupt ("corev-fast", "user")))
+foo(void);
+
+void __attribute__ ((interrupt ("corev-fast", "machine")))
+foo (void)
+{ /* { dg-error "function cannot have different interrupt type" } */
+}
+
+void __attribute__ ((interrupt))
+bar(void);
+
+void __attribute__ ((interrupt ("corev-fast")))
+bar (void)
+{ /* { dg-error "function cannot have different interrupt type" } */
+}

--- a/gcc/testsuite/gcc.target/riscv/cv-interrupt-debug.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-interrupt-debug.c
@@ -1,0 +1,16 @@
+/* Verify that we can compile with debug info.  */
+/* { dg-do compile } */
+/* { dg-options "" } */
+/* { dg-skip-if "" { *-*-* } { "*" } { "-g" } } */
+extern int var1;
+extern int var2;
+extern void sub2 (void);
+
+void __attribute__ ((interrupt ("corev-fast")))
+sub (void)
+{
+  if (var1)
+    var2 = 0;
+  else
+    sub2 ();
+}

--- a/gcc/testsuite/gcc.target/riscv/cv-interrupt-mmode.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-interrupt-mmode.c
@@ -1,0 +1,8 @@
+/* Verify the return instruction is mret.  */
+/* { dg-do compile } */
+/* { dg-options "" } */
+void __attribute__ ((interrupt ("corev-fast", "machine")))
+foo (void)
+{
+}
+/* { dg-final { scan-assembler "mret" } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-interrupt-smode.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-interrupt-smode.c
@@ -1,0 +1,8 @@
+/* Verify the return instruction is sret.  */
+/* { dg-do compile } */
+/* { dg-options "" } */
+void __attribute__ ((interrupt ("corev-fast", "supervisor")))
+foo (void)
+{
+}
+/* { dg-final { scan-assembler "sret" } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-interrupt-umode.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-interrupt-umode.c
@@ -1,0 +1,8 @@
+/* Verify the return instruction is uret.  */
+/* { dg-do compile } */
+/* { dg-options "" } */
+void __attribute__ ((interrupt ("corev-fast", "user")))
+foo (void)
+{
+}
+/* { dg-final { scan-assembler "uret" } } */

--- a/gcc/testsuite/gcc.target/riscv/interrupt-5.c
+++ b/gcc/testsuite/gcc.target/riscv/interrupt-5.c
@@ -17,5 +17,5 @@ sub2 (void)
 
 void __attribute__ ((interrupt ("hypervisor")))
 sub3 (void)
-{ /* { dg-warning "argument to" } */
+{ /* { dg-warning "argument 1 is not" } */
 }


### PR DESCRIPTION
Adds support for `__attribute__((interrupt("corev-fast", mode)))`, where mode is optional and is one of "machine", "supervisor" or "user".

CORE-V fast interrupt functions behave the same as standard RISC-V interrupt functions except they do not save caller saved registers (including ra, which the RISC-V ABI defines as caller saved but gcc treats as callee saved).