### PR TITLE
CORE-V: Fix typo in mac/msu tests

### DIFF
--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-test-autogeneration-mac.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-test-autogeneration-mac.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-02 -march=rv32im_xcvmac1p0 -mabi=ilp32" } */
+/* { dg-options "-O2 -march=rv32im_xcvmac1p0 -mabi=ilp32" } */
 
 int foo(int a, int b, int c)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-test-autogeneration-msu.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-test-autogeneration-msu.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-02 -march=rv32im_xcvmac1p0 -mabi=ilp32" } */
+/* { dg-options "-O2 -march=rv32im_xcvmac1p0 -mabi=ilp32" } */
 
 int foo(int a, int b, int c)
 {


### PR DESCRIPTION
gcc/testsuite/ChangeLog:

	* gcc.target/riscv/cv-march-xcvmac-test-autogeneration-mac.c: Replace -02 with -O2.
	* gcc.target/riscv/cv-march-xcvmac-test-autogeneration-msu.c: Likewise.

The tests pass for me after this change.