### PR TITLE
Backport CORE-V fast interrupts

### DIFF
--- a/gcc/config/riscv/corev.md
+++ b/gcc/config/riscv/corev.md
@@ -2716,8 +2716,8 @@
 
 (define_insn "riscv_cv_alu_addN"
   [(set (match_operand:SI 0 "register_operand" "=r,r")
-  (unspec:SI [(match_operand:SI 1 "register_operand" "r,r") 
-                      (match_operand:SI 2 "register_operand" "r,r") 
+  (unspec:SI [(match_operand:SI 1 "register_operand" "r,0")
+                      (match_operand:SI 2 "register_operand" "r,r")
                       (match_operand:QI 3 "csr_operand" "K,r")]
     UNSPEC_CV_ALU_ADDN))]
   "TARGET_XCVALU && !TARGET_64BIT"
@@ -2730,8 +2730,8 @@
 
 (define_insn "riscv_cv_alu_adduN"
   [(set (match_operand:SI 0 "register_operand" "=r,r")
-  (unspec:SI [(match_operand:SI 1 "register_operand" "r,r")
-  					(match_operand:SI 2 "register_operand" "r,r") 
+  (unspec:SI [(match_operand:SI 1 "register_operand" "r,0")
+					(match_operand:SI 2 "register_operand" "r,r")
 					(match_operand:QI 3 "csr_operand" "K,r")]
     UNSPEC_CV_ALU_ADDUN))]
   "TARGET_XCVALU && !TARGET_64BIT"
@@ -2744,7 +2744,7 @@
 
   (define_insn "riscv_cv_alu_addRN"
   [(set (match_operand:SI 0 "register_operand" "=r,r")
-  (unspec:SI [(match_operand:SI 1 "register_operand" "r,r")
+  (unspec:SI [(match_operand:SI 1 "register_operand" "r,0")
   (match_operand:SI 2 "register_operand" "r,r") 
   (match_operand:QI 3 "csr_operand" "K,r")]
     UNSPEC_CV_ALU_ADDRN))]
@@ -2758,7 +2758,7 @@
 
   (define_insn "riscv_cv_alu_adduRN"
   [(set (match_operand:SI 0 "register_operand" "=r,r")
-  (unspec:SI [(match_operand:SI 1 "register_operand" "r,r") 
+  (unspec:SI [(match_operand:SI 1 "register_operand" "r,0")
   (match_operand:SI 2 "register_operand" "r,r") 
   (match_operand:QI 3 "csr_operand" "K,r")]
     UNSPEC_CV_ALU_ADDURN))]
@@ -2772,7 +2772,7 @@
 
   (define_insn "riscv_cv_alu_subN"
   [(set (match_operand:SI 0 "register_operand" "=r,r")
-  (unspec:SI [(match_operand:SI 1 "register_operand" "r,r") 
+  (unspec:SI [(match_operand:SI 1 "register_operand" "r,0")
   (match_operand:SI 2 "register_operand" "r,r") 
   (match_operand:QI 3 "csr_operand" "K,r")]
     UNSPEC_CV_ALU_SUBN))]
@@ -2786,7 +2786,7 @@
 
   (define_insn "riscv_cv_alu_subuN"
   [(set (match_operand:SI 0 "register_operand" "=r,r")
-  (unspec:SI [(match_operand:SI 1 "register_operand" "r,r")
+  (unspec:SI [(match_operand:SI 1 "register_operand" "r,0")
   (match_operand:SI 2 "register_operand" "r,r")
   (match_operand:QI 3 "csr_operand" "K,r")]
     UNSPEC_CV_ALU_SUBUN))]
@@ -2800,7 +2800,7 @@
 
   (define_insn "riscv_cv_alu_subRN"
   [(set (match_operand:SI 0 "register_operand" "=r,r")
-  (unspec:SI [(match_operand:SI 1 "register_operand" "r,r") 
+  (unspec:SI [(match_operand:SI 1 "register_operand" "r,0")
   (match_operand:SI 2 "register_operand" "r,r") 
   (match_operand:QI 3 "csr_operand" "K,r")]
     UNSPEC_CV_ALU_SUBRN))]
@@ -2814,7 +2814,7 @@
 
   (define_insn "riscv_cv_alu_subuRN"
   [(set (match_operand:SI 0 "register_operand" "=r,r")
-  (unspec:SI [(match_operand:SI 1 "register_operand" "r,r") 
+  (unspec:SI [(match_operand:SI 1 "register_operand" "r,0")
   (match_operand:SI 2 "register_operand" "r,r") 
   (match_operand:QI 3 "csr_operand" "K,r")]
     UNSPEC_CV_ALU_SUBURN))]

--- a/gcc/config/riscv/corev.md
+++ b/gcc/config/riscv/corev.md
@@ -484,7 +484,7 @@
          UNSPEC_CV_BITMANIP_EXTRACT_INSN))]
 
   "TARGET_XCVBITMANIP && !TARGET_64BIT"
-  "cv.extract\t%0,%1,%2,%3"
+  "cv.extract\t%0,%1,%3,%2"
   [(set_attr "type" "bitmanip")
   (set_attr "mode" "SI")])
 
@@ -537,7 +537,7 @@
          UNSPEC_CV_BITMANIP_EXTRACTU_INSN))]
 
   "TARGET_XCVBITMANIP && !TARGET_64BIT"
-  "cv.extractu\t%0,%1,%2,%3"
+  "cv.extractu\t%0,%1,%3,%2"
   [(set_attr "type" "bitmanip")
   (set_attr "mode" "SI")])
 
@@ -588,7 +588,7 @@
          UNSPEC_CV_BITMANIP_INSERT_INSN))]
 
   "TARGET_XCVBITMANIP && !TARGET_64BIT"
-  "cv.insert\t%0,%1,%2,%3"
+  "cv.insert\t%0,%1,%3,%2"
   [(set_attr "type" "bitmanip")
   (set_attr "mode" "SI")])
 
@@ -642,7 +642,7 @@
          UNSPEC_CV_BITMANIP_BCLR_INSN))]
 
   "TARGET_XCVBITMANIP && !TARGET_64BIT"
-  "cv.bclr\t%0,%1,%2,%3"
+  "cv.bclr\t%0,%1,%3,%2"
   [(set_attr "type" "bitmanip")
   (set_attr "mode" "SI")])
 
@@ -692,7 +692,7 @@
          UNSPEC_CV_BITMANIP_BSET_INSN))]
 
   "TARGET_XCVBITMANIP && !TARGET_64BIT"
-  "cv.bset\t%0,%1,%2,%3"
+  "cv.bset\t%0,%1,%3,%2"
   [(set_attr "type" "bitmanip")
   (set_attr "mode" "SI")])
 

--- a/gcc/doc/extend.texi
+++ b/gcc/doc/extend.texi
@@ -6100,21 +6100,22 @@ basic @code{asm} and C code may appear to work, they cannot be
 depended upon to work reliably and are not supported.
 
 @item interrupt
+@itemx interrupt (mode)
+@itemx interrupt ("corev-fast", mode)
 @cindex @code{interrupt} function attribute, RISC-V
 Use this attribute to indicate that the specified function is an interrupt
 handler.  The compiler generates function entry and exit sequences suitable
 for use in an interrupt handler when this attribute is present.
 
-You can specify the kind of interrupt to be handled by adding an optional
-parameter to the interrupt attribute like this:
-
-@smallexample
-void f (void) __attribute__ ((interrupt ("user")));
-@end smallexample
-
+The optional @code{mode} parameter is used to specify the mode of the interrupt.
 Permissible values for this parameter are @code{user}, @code{supervisor},
 and @code{machine}.  If there is no parameter, then it defaults to
 @code{machine}.
+
+The optional @code{"corev-fast"} parameter specifies that the function is a
+CORE-V fast interrupt handler, which behaves the same as a normal interrupt
+handler except caller saved registers (including @code{ra}) are not saved by the
+function.
 @end table
 
 @node RL78 Function Attributes

--- a/gcc/testsuite/gcc.target/riscv/cv-interrupt-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-interrupt-1.c
@@ -1,0 +1,8 @@
+/* Verify the return instruction is mret.  */
+/* { dg-do compile } */
+/* { dg-options "" } */
+void __attribute__ ((interrupt ("corev-fast")))
+foo (void)
+{
+}
+/* { dg-final { scan-assembler "mret" } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-interrupt-2.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-interrupt-2.c
@@ -1,0 +1,13 @@
+/* Verify that arg regs used as temporaries do not get saved.  */
+/* { dg-do compile } */
+/* { dg-options "" } */
+void __attribute__ ((interrupt ("corev-fast")))
+foo2 (void)
+{
+  extern volatile int INTERRUPT_FLAG;
+  INTERRUPT_FLAG = 0;
+
+  extern volatile int COUNTER;
+  COUNTER++;
+}
+/* { dg-final { scan-assembler-not "s\[wd\]\ta\[0-7\],\[0-9\]+\\(sp\\)" } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-interrupt-3.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-interrupt-3.c
@@ -1,0 +1,10 @@
+/* Verify t0 is not saved before use.  */
+/* { dg-do compile } */
+/* { dg-options "-fomit-frame-pointer" } */
+/* { dg-skip-if "" { *-*-* } { "*" } { "-O0" } } */
+void __attribute__ ((interrupt ("corev-fast")))
+foo (void)
+{
+  char array[4096];
+}
+/* { dg-final { scan-assembler-not "s\[wd\]\tt0" } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-interrupt-4.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-interrupt-4.c
@@ -1,0 +1,19 @@
+/* Verify t0 is not saved before use.  */
+/* { dg-do compile } */
+/* { dg-options "-fomit-frame-pointer" } */
+/* { dg-skip-if "" { *-*-* } { "*" } { "-O0" } } */
+void __attribute__ ((interrupt ("corev-fast")))
+foo2 (void)
+{
+  char array[4096];
+  extern volatile int INTERRUPT_FLAG;
+  INTERRUPT_FLAG = 0;
+
+  extern volatile int COUNTER;
+#ifdef __riscv_atomic
+  __atomic_fetch_add (&COUNTER, 1, __ATOMIC_RELAXED);
+#else
+  COUNTER++;
+#endif
+}
+/* { dg-final { scan-assembler-not "s\[wd\]\tt0" } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-interrupt-5.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-interrupt-5.c
@@ -1,0 +1,71 @@
+/* Verify proper errors are generated for invalid code.  */
+int __attribute__ ((interrupt ("corev-fast")))
+sub0 (void)
+{ /* { dg-error "function cannot return a value" } */
+  return 10;
+}
+
+void __attribute__ ((interrupt ("corev-fast")))
+sub1 (int i)
+{ /* { dg-error "function cannot have arguments" } */
+}
+
+void __attribute__ ((interrupt ("corev-fast"), naked))
+sub2 (void)
+{ /* { dg-error "are mutually exclusive" } */
+}
+
+void __attribute__ ((interrupt ("corev-fast", "hypervisor")))
+sub3 (void)
+{ /* { dg-warning "argument 2 is not" } */
+}
+
+void __attribute__ ((interrupt ("machine", "corev-fast")))
+sub4 (void)
+{ /* { dg-warning "unexpected argument to" } */
+}
+
+void __attribute__ ((interrupt ("supervisor", "corev-fast")))
+sub5 (void)
+{ /* { dg-warning "unexpected argument to" } */
+}
+
+void __attribute__ ((interrupt ("user", "corev-fast")))
+sub6 (void)
+{ /* { dg-warning "unexpected argument to" } */
+}
+
+void __attribute__ ((interrupt ("", "corev-fast")))
+sub7 (void)
+{ /* { dg-warning "argument 1 is not" } */
+}
+
+void __attribute__ ((interrupt ("corev-fast", "")))
+sub8 (void)
+{ /* { dg-warning "argument 2 is not" } */
+}
+
+void __attribute__ ((interrupt (7)))
+sub9 (void)
+{ /* { dg-warning "argument 1 is not" } */
+}
+
+void __attribute__ ((interrupt ("corev-fast", 8)))
+sub10 (void)
+{ /* { dg-warning "argument 2 is not" } */
+}
+
+void __attribute__ ((interrupt ("corev-fast", "machine", "user")))
+sub11 (void)
+{ /* { dg-error "wrong number of arguments" } */
+}
+
+void __attribute__ ((interrupt ("machine", "user")))
+sub12 (void)
+{ /* { dg-warning "unexpected argument to" } */
+}
+
+void __attribute__ ((interrupt ("machine", "supervisor", "user")))
+sub13 (void)
+{ /* { dg-error "wrong number of arguments" } */
+}

--- a/gcc/testsuite/gcc.target/riscv/cv-interrupt-all-f-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-interrupt-all-f-1.c
@@ -1,0 +1,78 @@
+/* Verify all F registers are saved.  */
+/* { dg-do compile } */
+/* { dg-options "-fomit-frame-pointer -march=rv32if -mabi=ilp32f" } */
+void __attribute__ ((interrupt))
+foo (void)
+{
+  asm volatile ("" : : :  "f0",  "f1",  "f2",  "f3",  "f4",  "f5",  "f6",  "f7",
+			  "f8",  "f9", "f10", "f11", "f12", "f13", "f14", "f15",
+			 "f16", "f17", "f18", "f19", "f20", "f21", "f22", "f23",
+			 "f24", "f25", "f26", "f27", "f28", "f29", "f30", "f31"
+	       );
+}
+
+/* { dg-final { scan-assembler-times "flw\[ \t\]+ft0,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+ft1,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+ft2,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+ft3,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+ft4,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+ft5,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+ft6,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+ft7,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+fs0,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+fs1,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+fa0,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+fa1,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+fa2,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+fa3,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+fa4,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+fa5,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+fa6,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+fa7,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+fs2,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+fs3,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+fs4,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+fs5,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+fs6,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+fs7,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+fs8,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+fs9,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+fs10,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+fs11,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+ft8,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+ft9,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+ft10,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+ft11,\[0-9\]+\\(sp\\)" 1 } } */
+
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+ft0,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+ft1,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+ft2,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+ft3,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+ft4,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+ft5,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+ft6,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+ft7,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+fs0,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+fs1,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+fa0,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+fa1,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+fa2,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+fa3,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+fa4,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+fa5,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+fa6,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+fa7,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+fs2,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+fs3,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+fs4,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+fs5,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+fs6,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+fs7,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+fs8,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+fs9,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+fs10,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+fs11,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+ft8,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+ft9,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+ft10,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+ft11,\[0-9\]+\\(sp\\)" 1 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-interrupt-all-f-2.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-interrupt-all-f-2.c
@@ -1,0 +1,41 @@
+/* Verify only callee saved F registers are saved.  */
+/* { dg-do compile } */
+/* { dg-options "-fomit-frame-pointer -march=rv32if -mabi=ilp32f" } */
+void __attribute__ ((interrupt ("corev-fast")))
+foo (void)
+{
+  asm volatile ("" : : :  "f0",  "f1",  "f2",  "f3",  "f4",  "f5",  "f6",  "f7",
+			  "f8",  "f9", "f10", "f11", "f12", "f13", "f14", "f15",
+			 "f16", "f17", "f18", "f19", "f20", "f21", "f22", "f23",
+			 "f24", "f25", "f26", "f27", "f28", "f29", "f30", "f31"
+	       );
+}
+
+/* { dg-final { scan-assembler-not "f\[sl\]w\[ \t\]+fa" } } */
+/* { dg-final { scan-assembler-not "f\[sl\]w\[ \t\]+ft" } } */
+
+/* { dg-final { scan-assembler-times "flw\[ \t\]+fs0,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+fs1,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+fs2,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+fs3,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+fs4,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+fs5,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+fs6,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+fs7,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+fs8,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+fs9,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+fs10,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "flw\[ \t\]+fs11,\[0-9\]+\\(sp\\)" 1 } } */
+
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+fs0,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+fs1,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+fs2,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+fs3,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+fs4,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+fs5,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+fs6,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+fs7,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+fs8,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+fs9,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+fs10,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "fsw\[ \t\]+fs11,\[0-9\]+\\(sp\\)" 1 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-interrupt-all-x-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-interrupt-all-x-1.c
@@ -1,0 +1,75 @@
+/* Verify all X registers are saved except x0, sp, gp, tp.  */
+/* { dg-do compile } */
+/* { dg-options "-fomit-frame-pointer" } */
+void __attribute__ ((interrupt))
+foo (void)
+{
+  /* Clobber all registers except sp which is not allowed.  */
+  asm volatile ("" : : :  "x0",  "x1",  "x3",  "x4",  "x5",  "x6",  "x7",  "x8",
+  	                  "x9", "x10", "x11", "x12", "x13", "x14", "x15", "x16",
+  	                 "x17", "x18", "x19", "x20", "x21", "x22", "x23", "x24",
+  	                 "x25", "x26", "x27", "x28", "x29", "x30", "x31");
+}
+
+/* { dg-final { scan-assembler-not "\[sl\]w\[ \t\]+zero" } } */
+/* { dg-final { scan-assembler-not "\[sl\]w\[ \t\]+sp" } } */
+/* { dg-final { scan-assembler-not "\[sl\]w\[ \t\]+gp" } } */
+/* { dg-final { scan-assembler-not "\[sl\]w\[ \t\]+tp" } } */
+
+/* { dg-final { scan-assembler-times "lw\[ \t\]+ra,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+t0,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+t1,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+t2,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+s0,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+s1,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+a0,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+a1,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+a2,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+a3,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+a4,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+a5,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+a6,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+a7,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+s2,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+s3,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+s4,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+s5,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+s6,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+s7,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+s8,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+s9,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+s10,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+s11,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+t3,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+t4,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+t5,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+t6,\[0-9\]+\\(sp\\)" 1 } } */
+
+/* { dg-final { scan-assembler-times "sw\[ \t\]+ra,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+t0,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+t1,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+t2,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+s0,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+s1,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+a0,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+a1,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+a2,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+a3,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+a4,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+a5,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+a6,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+a7,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+s2,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+s3,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+s4,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+s5,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+s6,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+s7,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+s8,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+s9,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+s10,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+s11,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+t3,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+t4,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+t5,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+t6,\[0-9\]+\\(sp\\)" 1 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-interrupt-all-x-2.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-interrupt-all-x-2.c
@@ -1,0 +1,47 @@
+/* Verify only callee saved X registers are saved.  */
+/* { dg-do compile } */
+/* { dg-options "-fomit-frame-pointer" } */
+void __attribute__ ((interrupt ("corev-fast")))
+foo (void)
+{
+  /* Clobber all registers except sp which is not allowed.  */
+  asm volatile ("" : : :  "x0",  "x1",  "x3",  "x4",  "x5",  "x6",  "x7",  "x8",
+  	                  "x9", "x10", "x11", "x12", "x13", "x14", "x15", "x16",
+  	                 "x17", "x18", "x19", "x20", "x21", "x22", "x23", "x24",
+  	                 "x25", "x26", "x27", "x28", "x29", "x30", "x31");
+}
+
+/* { dg-final { scan-assembler-not "\[sl\]w\[ \t\]+zero" } } */
+/* { dg-final { scan-assembler-not "\[sl\]w\[ \t\]+sp" } } */
+/* { dg-final { scan-assembler-not "\[sl\]w\[ \t\]+gp" } } */
+/* { dg-final { scan-assembler-not "\[sl\]w\[ \t\]+tp" } } */
+
+/* { dg-final { scan-assembler-not "\[sl\]w\[ \t\]+ra" } } */
+/* { dg-final { scan-assembler-not "\[sl\]w\[ \t\]+a\[0-7\]" } } */
+/* { dg-final { scan-assembler-not "\[sl\]w\[ \t\]+t\[0-6\]" } } */
+
+/* { dg-final { scan-assembler-times "lw\[ \t\]+s0,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+s1,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+s2,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+s3,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+s4,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+s5,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+s6,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+s7,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+s8,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+s9,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+s10,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+s11,\[0-9\]+\\(sp\\)" 1 } } */
+
+/* { dg-final { scan-assembler-times "sw\[ \t\]+s0,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+s1,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+s2,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+s3,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+s4,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+s5,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+s6,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+s7,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+s8,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+s9,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+s10,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+s11,\[0-9\]+\\(sp\\)" 1 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-interrupt-all-x-3.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-interrupt-all-x-3.c
@@ -1,0 +1,50 @@
+/* Verify a non-leaf interrupt saves all caller saved registers except x0, sp,
+   gp, tp.  */
+/* { dg-do compile } */
+/* { dg-options "-fomit-frame-pointer" } */
+extern void bar (void);
+
+void __attribute__ ((interrupt))
+foo (void)
+{
+  bar ();
+}
+
+/* { dg-final { scan-assembler-not "\[sl\]w\[ \t\]+zero" } } */
+/* { dg-final { scan-assembler-not "\[sl\]w\[ \t\]+sp" } } */
+/* { dg-final { scan-assembler-not "\[sl\]w\[ \t\]+gp" } } */
+/* { dg-final { scan-assembler-not "\[sl\]w\[ \t\]+tp" } } */
+
+/* { dg-final { scan-assembler-times "lw\[ \t\]+ra,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+t0,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+t1,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+t2,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+a0,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+a1,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+a2,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+a3,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+a4,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+a5,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+a6,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+a7,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+t3,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+t4,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+t5,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "lw\[ \t\]+t6,\[0-9\]+\\(sp\\)" 1 } } */
+
+/* { dg-final { scan-assembler-times "sw\[ \t\]+ra,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+t0,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+t1,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+t2,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+a0,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+a1,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+a2,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+a3,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+a4,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+a5,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+a6,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+a7,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+t3,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+t4,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+t5,\[0-9\]+\\(sp\\)" 1 } } */
+/* { dg-final { scan-assembler-times "sw\[ \t\]+t6,\[0-9\]+\\(sp\\)" 1 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-interrupt-all-x-4.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-interrupt-all-x-4.c
@@ -1,0 +1,19 @@
+/* Verify a non-leaf interrupt does not save any caller saved registers.  */
+/* { dg-do compile } */
+/* { dg-options "-fomit-frame-pointer" } */
+extern void bar (void);
+
+void __attribute__ ((interrupt ("corev-fast")))
+foo (void)
+{
+  bar ();
+}
+
+/* { dg-final { scan-assembler-not "\[sl\]w\[ \t\]+zero" } } */
+/* { dg-final { scan-assembler-not "\[sl\]w\[ \t\]+sp" } } */
+/* { dg-final { scan-assembler-not "\[sl\]w\[ \t\]+gp" } } */
+/* { dg-final { scan-assembler-not "\[sl\]w\[ \t\]+tp" } } */
+
+/* { dg-final { scan-assembler-not "\[sl\]w\[ \t\]+ra" } } */
+/* { dg-final { scan-assembler-not "\[sl\]w\[ \t\]+a\[0-7\]" } } */
+/* { dg-final { scan-assembler-not "\[sl\]w\[ \t\]+t\[0-6\]" } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-interrupt-conflict-type.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-interrupt-conflict-type.c
@@ -1,0 +1,18 @@
+/* Verify proper errors are generated for conflicting interrupt type.  */
+/* { dg-do compile } */
+/* { dg-options "" } */
+void __attribute__ ((interrupt ("corev-fast", "user")))
+foo(void);
+
+void __attribute__ ((interrupt ("corev-fast", "machine")))
+foo (void)
+{ /* { dg-error "function cannot have different interrupt type" } */
+}
+
+void __attribute__ ((interrupt))
+bar(void);
+
+void __attribute__ ((interrupt ("corev-fast")))
+bar (void)
+{ /* { dg-error "function cannot have different interrupt type" } */
+}

--- a/gcc/testsuite/gcc.target/riscv/cv-interrupt-debug.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-interrupt-debug.c
@@ -1,0 +1,16 @@
+/* Verify that we can compile with debug info.  */
+/* { dg-do compile } */
+/* { dg-options "" } */
+/* { dg-skip-if "" { *-*-* } { "*" } { "-g" } } */
+extern int var1;
+extern int var2;
+extern void sub2 (void);
+
+void __attribute__ ((interrupt ("corev-fast")))
+sub (void)
+{
+  if (var1)
+    var2 = 0;
+  else
+    sub2 ();
+}

--- a/gcc/testsuite/gcc.target/riscv/cv-interrupt-mmode.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-interrupt-mmode.c
@@ -1,0 +1,8 @@
+/* Verify the return instruction is mret.  */
+/* { dg-do compile } */
+/* { dg-options "" } */
+void __attribute__ ((interrupt ("corev-fast", "machine")))
+foo (void)
+{
+}
+/* { dg-final { scan-assembler "mret" } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-interrupt-smode.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-interrupt-smode.c
@@ -1,0 +1,8 @@
+/* Verify the return instruction is sret.  */
+/* { dg-do compile } */
+/* { dg-options "" } */
+void __attribute__ ((interrupt ("corev-fast", "supervisor")))
+foo (void)
+{
+}
+/* { dg-final { scan-assembler "sret" } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-interrupt-umode.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-interrupt-umode.c
@@ -1,0 +1,8 @@
+/* Verify the return instruction is uret.  */
+/* { dg-do compile } */
+/* { dg-options "" } */
+void __attribute__ ((interrupt ("corev-fast", "user")))
+foo (void)
+{
+}
+/* { dg-final { scan-assembler "uret" } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-compile-bclr.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-compile-bclr.c
@@ -21,8 +21,7 @@ foo (uint32_t a)
   return res1 + res2 + res3 + res4;
 }
 
-/* { dg-final { scan-assembler-times "cv\.bclr\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),6,8" 1 } } */
+/* { dg-final { scan-assembler-times "cv\.bclr\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),8,6" 1 } } */
 /* { dg-final { scan-assembler-times "cv\.bclr\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),0,0" 1 } } */
-/* { dg-final { scan-assembler-times "cv\.bclr\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),0,31" 1 } } */
+/* { dg-final { scan-assembler-times "cv\.bclr\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),31,0" 1 } } */
 /* { dg-final { scan-assembler-times "cv\.bclr\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),31,31" 1 } } */
-

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-compile-bset.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-compile-bset.c
@@ -21,7 +21,7 @@ foo (uint32_t a)
   return res1 + res2 + res3 + res4;
 }
 
-/* { dg-final { scan-assembler-times "cv\.bset\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),6,8" 1 } } */
+/* { dg-final { scan-assembler-times "cv\.bset\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),8,6" 1 } } */
 /* { dg-final { scan-assembler-times "cv\.bset\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),0,0" 1 } } */
-/* { dg-final { scan-assembler-times "cv\.bset\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),0,31" 1 } } */
+/* { dg-final { scan-assembler-times "cv\.bset\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),31,0" 1 } } */
 /* { dg-final { scan-assembler-times "cv\.bset\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),31,31" 1 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-compile-extract.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-compile-extract.c
@@ -21,7 +21,7 @@ foo (int32_t a)
   return res1 + res2 + res3 + res4;
 }
 
-/* { dg-final { scan-assembler-times "cv\.extract\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),6,8" 1 } } */
+/* { dg-final { scan-assembler-times "cv\.extract\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),8,6" 1 } } */
 /* { dg-final { scan-assembler-times "cv\.extract\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),0,0" 1 } } */
-/* { dg-final { scan-assembler-times "cv\.extract\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),0,31" 1 } } */
+/* { dg-final { scan-assembler-times "cv\.extract\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),31,0" 1 } } */
 /* { dg-final { scan-assembler-times "cv\.extract\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),31,31" 1 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-compile-extractu.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-compile-extractu.c
@@ -21,7 +21,7 @@ foo (uint32_t a)
   return res1 + res2 + res3 + res4;
 }
 
-/* { dg-final { scan-assembler-times "cv\.extractu\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),6,8" 1 } } */
+/* { dg-final { scan-assembler-times "cv\.extractu\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),8,6" 1 } } */
 /* { dg-final { scan-assembler-times "cv\.extractu\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),0,0" 1 } } */
-/* { dg-final { scan-assembler-times "cv\.extractu\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),0,31" 1 } } */
+/* { dg-final { scan-assembler-times "cv\.extractu\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),31,0" 1 } } */
 /* { dg-final { scan-assembler-times "cv\.extractu\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),31,31" 1 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-compile-insert.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-compile-insert.c
@@ -19,6 +19,6 @@ foo (uint32_t a, uint32_t b)
   return res1 + res2 + res3;
 }
 
-/* { dg-final { scan-assembler-times "cv\.insert\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),6,8" 1 } } */
+/* { dg-final { scan-assembler-times "cv\.insert\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),8,6" 1 } } */
 /* { dg-final { scan-assembler-times "cv\.insert\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),0,0" 1 } } */
-/* { dg-final { scan-assembler-times "cv\.insert\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),0,31" 1 } } */
+/* { dg-final { scan-assembler-times "cv\.insert\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),31,0" 1 } } */

--- a/gcc/testsuite/gcc.target/riscv/interrupt-5.c
+++ b/gcc/testsuite/gcc.target/riscv/interrupt-5.c
@@ -17,5 +17,5 @@ sub2 (void)
 
 void __attribute__ ((interrupt ("hypervisor")))
 sub3 (void)
-{ /* { dg-warning "argument to" } */
+{ /* { dg-warning "argument 1 is not" } */
 }


### PR DESCRIPTION
Backport CORE-V fast interrupts to the old development branch which included zcmt support.

I have also backported a couple of fixes from `development`.