### PR TITLE
CORE-V: Remove versioning support for XCV Extensions

### DIFF
--- a/gcc/testsuite/gcc.target/riscv/cv-bi-beqimm-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-bi-beqimm-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvbi1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvbi -mabi=ilp32" } */
 /* { dg-skip-if "" { *-*-* }  { "-O0" } { "" } } */
 
 /* __builtin_expect is used to provide the compiler with

--- a/gcc/testsuite/gcc.target/riscv/cv-bi-beqimm-compile-2.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-bi-beqimm-compile-2.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvbi1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvbi -mabi=ilp32" } */
 /* { dg-skip-if "" { *-*-* }  { "-O0" } { "" } } */
 
 /* __builtin_expect is used to provide the compiler with

--- a/gcc/testsuite/gcc.target/riscv/cv-bi-bneimm-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-bi-bneimm-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvbi1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvbi -mabi=ilp32" } */
 /* { dg-skip-if "" { *-*-* }  { "-O0" } { "" } } */
 
 /* __builtin_expect is used to provide the compiler with

--- a/gcc/testsuite/gcc.target/riscv/cv-bi-bneimm-compile-2.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-bi-bneimm-compile-2.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvbi1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvbi -mabi=ilp32" } */
 /* { dg-skip-if "" { *-*-* }  { "-O0" } { "" } } */
 
 /* __builtin_expect is used to provide the compiler with

--- a/gcc/testsuite/gcc.target/riscv/cv-elw-elw-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-elw-elw-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvelw1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvelw -mabi=ilp32" } */
 
 int foo1(int* b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-compile-addn.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-compile-addn.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_alu } */
-/* { dg-options "-march=rv32i_xcvalu1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvalu -mabi=ilp32" } */
 
 extern int d;
 extern int e;

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-compile-addnr.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-compile-addnr.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_alu } */
-/* { dg-options "-march=rv32i_xcvalu1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvalu -mabi=ilp32" } */
 
 #include <stdint.h>
 

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-compile-addrn.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-compile-addrn.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_alu } */
-/* { dg-options "-march=rv32i_xcvalu1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvalu -mabi=ilp32" } */
 
 extern int d;
 extern int e;

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-compile-addrnr.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-compile-addrnr.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_alu } */
-/* { dg-options "-march=rv32i_xcvalu1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvalu -mabi=ilp32" } */
 
 int foo1(int a, int b, int c)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-compile-addun.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-compile-addun.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_alu } */
-/* { dg-options "-march=rv32i_xcvalu1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvalu -mabi=ilp32" } */
 
 extern int d;
 extern int e;

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-compile-addunr.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-compile-addunr.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_alu } */
-/* { dg-options "-march=rv32i_xcvalu1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvalu -mabi=ilp32" } */
 
 int foo1(int a, int b, int c)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-compile-addurn.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-compile-addurn.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_alu } */
-/* { dg-options "-march=rv32i_xcvalu1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvalu -mabi=ilp32" } */
 
 extern int d;
 extern int e;

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-compile-addurnr.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-compile-addurnr.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_alu } */
-/* { dg-options "-march=rv32i_xcvalu1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvalu -mabi=ilp32" } */
 
 int foo1(int a, int b, int c)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-compile-clip.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-compile-clip.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_alu } */
-/* { dg-options "-march=rv32i_xcvalu1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvalu -mabi=ilp32" } */
 
 int foo1(int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-compile-clipr.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-compile-clipr.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_alu } */
-/* { dg-options "-march=rv32i_xcvalu1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvalu -mabi=ilp32" } */
 
 int foo1(int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-compile-clipu.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-compile-clipu.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_alu } */
-/* { dg-options "-march=rv32i_xcvalu1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvalu -mabi=ilp32" } */
 
 int foo1(int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-compile-clipur.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-compile-clipur.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_alu } */
-/* { dg-options "-march=rv32i_xcvalu1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvalu -mabi=ilp32" } */
 
 int foo1(int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-compile-extbs.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-compile-extbs.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_alu } */
-/* { dg-options "-march=rv32i_xcvalu1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvalu -mabi=ilp32" } */
 
 #include <stdint.h>
 

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-compile-extbz.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-compile-extbz.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_alu } */
-/* { dg-options "-march=rv32i_xcvalu1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvalu -mabi=ilp32" } */
 
 #include <stdint.h>
 

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-compile-exths.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-compile-exths.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_alu } */
-/* { dg-options "-march=rv32i_xcvalu1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvalu -mabi=ilp32" } */
 
 #include <stdint.h>
 

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-compile-exthz.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-compile-exthz.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_alu } */
-/* { dg-options "-march=rv32i_xcvalu1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvalu -mabi=ilp32" } */
 
 #include <stdint.h>
 

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-compile-max.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-compile-max.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_alu } */
-/* { dg-options "-march=rv32i_xcvalu1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvalu -mabi=ilp32" } */
 
 int foo1(int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-compile-maxu.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-compile-maxu.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_alu } */
-/* { dg-options "-march=rv32i_xcvalu1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvalu -mabi=ilp32" } */
 
 int foo1(int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-compile-min.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-compile-min.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_alu } */
-/* { dg-options "-march=rv32i_xcvalu1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvalu -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-compile-minu.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-compile-minu.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_alu } */
-/* { dg-options "-march=rv32i_xcvalu1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvalu -mabi=ilp32" } */
 
 int foo1(int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-compile-slet.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-compile-slet.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_alu } */
-/* { dg-options "-march=rv32i_xcvalu1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvalu -mabi=ilp32" } */
 
 int foo1(int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-compile-sletu.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-compile-sletu.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_alu } */
-/* { dg-options "-march=rv32i_xcvalu1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvalu -mabi=ilp32" } */
 
 #include <stdint.h>
 

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-compile-subn.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-compile-subn.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_alu } */
-/* { dg-options "-march=rv32i_xcvalu1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvalu -mabi=ilp32" } */
 
 extern int d;
 extern int e;

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-compile-subnr.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-compile-subnr.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_alu } */
-/* { dg-options "-march=rv32i_xcvalu1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvalu -mabi=ilp32" } */
 
 int foo1(int a, int b, int c)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-compile-subrn.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-compile-subrn.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_alu } */
-/* { dg-options "-march=rv32i_xcvalu1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvalu -mabi=ilp32" } */
 
 extern int d;
 extern int e;

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-compile-subrnr.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-compile-subrnr.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_alu } */
-/* { dg-options "-march=rv32i_xcvalu1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvalu -mabi=ilp32" } */
 
 int foo1(int a, int b, int c)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-compile-subun.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-compile-subun.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_alu } */
-/* { dg-options "-march=rv32i_xcvalu1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvalu -mabi=ilp32" } */
 
 extern int d;
 extern int e;

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-compile-subunr.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-compile-subunr.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_alu } */
-/* { dg-options "-march=rv32i_xcvalu1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvalu -mabi=ilp32" } */
 
 int foo1(int a, int b, int c)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-compile-suburn.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-compile-suburn.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_alu } */
-/* { dg-options "-march=rv32i_xcvalu1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvalu -mabi=ilp32" } */
 
 extern int d;
 extern int e;

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-compile-suburnr.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-compile-suburnr.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_alu } */
-/* { dg-options "-march=rv32i_xcvalu1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvalu -mabi=ilp32" } */
 
 int foo1(int a, int b, int c)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-fail-compile-addn.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-fail-compile-addn.c
@@ -1,7 +1,7 @@
 
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_alu } */
-/* { dg-options "-march=rv32i_xcvalu1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvalu -mabi=ilp32" } */
 
 extern int d;
 

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-fail-compile-addrn.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-fail-compile-addrn.c
@@ -1,7 +1,7 @@
 
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_alu } */
-/* { dg-options "-march=rv32i_xcvalu1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvalu -mabi=ilp32" } */
 
 extern int d;
 

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-fail-compile-addun.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-fail-compile-addun.c
@@ -1,7 +1,7 @@
 
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_alu } */
-/* { dg-options "-march=rv32i_xcvalu1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvalu -mabi=ilp32" } */
 
 extern int d;
 

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-fail-compile-addurn.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-fail-compile-addurn.c
@@ -1,7 +1,7 @@
 
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_alu } */
-/* { dg-options "-march=rv32i_xcvalu1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvalu -mabi=ilp32" } */
 
 extern int d;
 

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-fail-compile-clip.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-fail-compile-clip.c
@@ -1,7 +1,7 @@
 
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_alu } */
-/* { dg-options "-march=rv32i_xcvalu1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvalu -mabi=ilp32" } */
 
 extern int d;
 

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-fail-compile-clipu.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-fail-compile-clipu.c
@@ -1,7 +1,7 @@
 
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_alu } */
-/* { dg-options "-march=rv32i_xcvalu1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvalu -mabi=ilp32" } */
 
 extern int d;
 

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-fail-compile-subn.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-fail-compile-subn.c
@@ -1,7 +1,7 @@
 
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_alu } */
-/* { dg-options "-march=rv32i_xcvalu1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvalu -mabi=ilp32" } */
 
 extern int d;
 

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-fail-compile-subrn.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-fail-compile-subrn.c
@@ -1,7 +1,7 @@
 
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_alu } */
-/* { dg-options "-march=rv32i_xcvalu1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvalu -mabi=ilp32" } */
 
 extern int d;
 

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-fail-compile-subun.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-fail-compile-subun.c
@@ -1,7 +1,7 @@
 
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_alu } */
-/* { dg-options "-march=rv32i_xcvalu1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvalu -mabi=ilp32" } */
 
 extern int d;
 

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-fail-compile-suburn.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-fail-compile-suburn.c
@@ -1,7 +1,7 @@
 
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_alu } */
-/* { dg-options "-march=rv32i_xcvalu1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvalu -mabi=ilp32" } */
 
 extern int d;
 

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-compile-bclr.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-compile-bclr.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_bitmanip } */
-/* { dg-options "-march=rv32i_xcvbitmanip1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvbitmanip -mabi=ilp32" } */
 
 #include <stdint.h>
 #include <stdio.h>

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-compile-bclrr.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-compile-bclrr.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_bitmanip } */
-/* { dg-options "-march=rv32i_xcvbitmanip1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvbitmanip -mabi=ilp32" } */
 
 #include <stdint.h>
 #include <stdio.h>

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-compile-bitrev.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-compile-bitrev.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_bitmanip } */
-/* { dg-options "-march=rv32i_xcvbitmanip1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvbitmanip -mabi=ilp32" } */
 
 #include <stdint.h>
 #include <stdio.h>

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-compile-bset.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-compile-bset.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_bitmanip } */
-/* { dg-options "-march=rv32i_xcvbitmanip1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvbitmanip -mabi=ilp32" } */
 
 #include <stdint.h>
 #include <stdio.h>

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-compile-bsetr.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-compile-bsetr.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_bitmanip } */
-/* { dg-options "-march=rv32i_xcvbitmanip1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvbitmanip -mabi=ilp32" } */
 
 #include <stdint.h>
 #include <stdio.h>

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-compile-clb.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-compile-clb.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_bitmanip } */
-/* { dg-options "-march=rv32i_xcvbitmanip1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvbitmanip -mabi=ilp32" } */
 
 #include <stdint.h>
 #include <stdio.h>

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-compile-cnt.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-compile-cnt.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_bitmanip } */
-/* { dg-options "-march=rv32i_xcvbitmanip1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvbitmanip -mabi=ilp32" } */
 
 #include <stdint.h>
 #include <stdio.h>

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-compile-extract.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-compile-extract.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_bitmanip } */
-/* { dg-options "-march=rv32i_xcvbitmanip1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvbitmanip -mabi=ilp32" } */
 
 #include <stdint.h>
 #include <stdio.h>

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-compile-extractr.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-compile-extractr.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_bitmanip } */
-/* { dg-options "-march=rv32i_xcvbitmanip1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvbitmanip -mabi=ilp32" } */
 
 #include <stdint.h>
 #include <stdio.h>

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-compile-extractu.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-compile-extractu.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_bitmanip } */
-/* { dg-options "-march=rv32i_xcvbitmanip1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvbitmanip -mabi=ilp32" } */
 
 #include <stdint.h>
 #include <stdio.h>

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-compile-extractur.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-compile-extractur.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_bitmanip } */
-/* { dg-options "-march=rv32i_xcvbitmanip1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvbitmanip -mabi=ilp32" } */
 
 #include <stdint.h>
 #include <stdio.h>

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-compile-ff1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-compile-ff1.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_bitmanip } */
-/* { dg-options "-march=rv32i_xcvbitmanip1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvbitmanip -mabi=ilp32" } */
 
 #include <stdint.h>
 #include <stdio.h>

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-compile-fl1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-compile-fl1.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_bitmanip } */
-/* { dg-options "-march=rv32i_xcvbitmanip1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvbitmanip -mabi=ilp32" } */
 
 #include <stdint.h>
 #include <stdio.h>

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-compile-insert.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-compile-insert.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_bitmanip } */
-/* { dg-options "-march=rv32i_xcvbitmanip1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvbitmanip -mabi=ilp32" } */
 
 #include <stdint.h>
 #include <stdio.h>

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-compile-insertr.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-compile-insertr.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_bitmanip } */
-/* { dg-options "-march=rv32i_xcvbitmanip1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvbitmanip -mabi=ilp32" } */
 
 #include <stdint.h>
 #include <stdio.h>

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-compile-ror.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-compile-ror.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_bitmanip } */
-/* { dg-options "-march=rv32i_xcvbitmanip1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvbitmanip -mabi=ilp32" } */
 
 #include <stdint.h>
 #include <stdio.h>

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-fail-compile-bclr.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-fail-compile-bclr.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_bitmanip } */
-/* { dg-options "-march=rv32i_xcvbitmanip1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvbitmanip -mabi=ilp32" } */
 /* { dg-skip-if "Skip LTO tests of builtin compilation" { *-*-* } { "-flto" } } */
 
 #include <stdint.h>

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-fail-compile-bitrev.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-fail-compile-bitrev.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_bitmanip } */
-/* { dg-options "-march=rv32i_xcvbitmanip1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvbitmanip -mabi=ilp32" } */
 /* { dg-skip-if "Skip LTO tests of builtin compilation" { *-*-* } { "-flto" } } */
 
 #include <stdint.h>

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-fail-compile-bset.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-fail-compile-bset.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_bitmanip } */
-/* { dg-options "-march=rv32i_xcvbitmanip1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvbitmanip -mabi=ilp32" } */
 /* { dg-skip-if "Skip LTO tests of builtin compilation" { *-*-* } { "-flto" } } */
 
 #include <stdint.h>

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-fail-compile-extract.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-fail-compile-extract.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_bitmanip } */
-/* { dg-options "-march=rv32i_xcvbitmanip1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvbitmanip -mabi=ilp32" } */
 /* { dg-skip-if "Skip LTO tests of builtin compilation" { *-*-* } { "-flto" } } */
 
 #include <stdint.h>

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-fail-compile-extractu.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-fail-compile-extractu.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_bitmanip } */
-/* { dg-options "-march=rv32i_xcvbitmanip1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvbitmanip -mabi=ilp32" } */
 /* { dg-skip-if "Skip LTO tests of builtin compilation" { *-*-* } { "-flto" } } */
 
 #include <stdint.h>

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-fail-compile-insert.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-fail-compile-insert.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_bitmanip } */
-/* { dg-options "-march=rv32i_xcvbitmanip1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvbitmanip -mabi=ilp32" } */
 /* { dg-skip-if "Skip LTO tests of builtin compilation" { *-*-* } { "-flto" } } */
 
 #include <stdint.h>

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-compile-mac.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-compile-mac.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_mac } */
-/* { dg-options "-march=rv32i_xcvmac1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvmac -mabi=ilp32" } */
 
 int foo(int a, int b, int c)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-compile-machhsn.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-compile-machhsn.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_mac } */
-/* { dg-options "-march=rv32i_xcvmac1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvmac -mabi=ilp32" } */
 
 extern int d;
 extern int e;

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-compile-machhsrn.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-compile-machhsrn.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_mac } */
-/* { dg-options "-march=rv32i_xcvmac1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvmac -mabi=ilp32" } */
 
 extern int d;
 extern int e;

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-compile-machhun.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-compile-machhun.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_mac } */
-/* { dg-options "-march=rv32i_xcvmac1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvmac -mabi=ilp32" } */
 
 extern int d;
 extern int e;

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-compile-machhurn.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-compile-machhurn.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_mac } */
-/* { dg-options "-march=rv32i_xcvmac1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvmac -mabi=ilp32" } */
 
 extern int d;
 extern int e;

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-compile-macsn.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-compile-macsn.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_mac } */
-/* { dg-options "-march=rv32i_xcvmac1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvmac -mabi=ilp32" } */
 
 extern int d;
 extern int e;

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-compile-macsrn.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-compile-macsrn.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_mac } */
-/* { dg-options "-march=rv32i_xcvmac1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvmac -mabi=ilp32" } */
 
 extern int d;
 extern int e;

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-compile-macun.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-compile-macun.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_mac } */
-/* { dg-options "-march=rv32i_xcvmac1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvmac -mabi=ilp32" } */
 
 extern int d;
 extern int e;

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-compile-macurn.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-compile-macurn.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_mac } */
-/* { dg-options "-march=rv32i_xcvmac1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvmac -mabi=ilp32" } */
 
 extern int d;
 extern int e;

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-compile-msu.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-compile-msu.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_mac } */
-/* { dg-options "-march=rv32i_xcvmac1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvmac -mabi=ilp32" } */
 
 int foo(int a, int b, int c)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-compile-mulhhsn.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-compile-mulhhsn.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_mac } */
-/* { dg-options "-march=rv32i_xcvmac1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvmac -mabi=ilp32" } */
 
 extern int d;
 extern int e;

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-compile-mulhhsrn.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-compile-mulhhsrn.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_mac } */
-/* { dg-options "-march=rv32i_xcvmac1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvmac -mabi=ilp32" } */
 
 extern int d;
 extern int e;

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-compile-mulhhun.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-compile-mulhhun.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_mac } */
-/* { dg-options "-march=rv32i_xcvmac1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvmac -mabi=ilp32" } */
 
 extern int d;
 extern int e;

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-compile-mulhhurn.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-compile-mulhhurn.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_mac } */
-/* { dg-options "-march=rv32i_xcvmac1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvmac -mabi=ilp32" } */
 
 extern int d;
 extern int e;

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-compile-mulsn.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-compile-mulsn.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_mac } */
-/* { dg-options "-march=rv32i_xcvmac1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvmac -mabi=ilp32" } */
 
 extern int d;
 extern int e;

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-compile-mulsrn.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-compile-mulsrn.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_mac } */
-/* { dg-options "-march=rv32i_xcvmac1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvmac -mabi=ilp32" } */
 
 extern int d;
 extern int e;

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-compile-mulun.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-compile-mulun.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_mac } */
-/* { dg-options "-march=rv32i_xcvmac1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvmac -mabi=ilp32" } */
 
 extern int d;
 extern int e;

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-compile-mulurn.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-compile-mulurn.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_mac } */
-/* { dg-options "-march=rv32i_xcvmac1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvmac -mabi=ilp32" } */
 
 extern int d;
 extern int e;

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-fail-compile-mac.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-fail-compile-mac.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_mac } */
-/* { dg-options "-march=rv32i_xcvmac1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvmac -mabi=ilp32" } */
 
 #include <stdint.h>
 #include<stdio.h>

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-fail-compile-machhsn.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-fail-compile-machhsn.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_mac } */
-/* { dg-options "-march=rv32i_xcvmac1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvmac -mabi=ilp32" } */
 /* { dg-skip-if "Skip LTO tests of builtin compilation" { *-*-* } { "-flto" } } */ 
 
 #include <stdint.h>

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-fail-compile-machhsrn.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-fail-compile-machhsrn.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_mac } */
-/* { dg-options "-march=rv32i_xcvmac1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvmac -mabi=ilp32" } */
 /* { dg-skip-if "Skip LTO tests of builtin compilation" { *-*-* } { "-flto" } } */
 
 #include <stdint.h>

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-fail-compile-machhun.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-fail-compile-machhun.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_mac } */
-/* { dg-options "-march=rv32i_xcvmac1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvmac -mabi=ilp32" } */
 /* { dg-skip-if "Skip LTO tests of builtin compilation" { *-*-* } { "-flto" } } */
 
 #include <stdint.h>

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-fail-compile-machhurn.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-fail-compile-machhurn.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_mac } */
-/* { dg-options "-march=rv32i_xcvmac1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvmac -mabi=ilp32" } */
 /* { dg-skip-if "Skip LTO tests of builtin compilation" { *-*-* } { "-flto" } } */
 
 #include <stdint.h>

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-fail-compile-macsn.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-fail-compile-macsn.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_mac } */
-/* { dg-options "-march=rv32i_xcvmac1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvmac -mabi=ilp32" } */
 /* { dg-skip-if "Skip LTO tests of builtin compilation" { *-*-* } { "-flto" } } */
 
 #include <stdint.h>

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-fail-compile-macsrn.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-fail-compile-macsrn.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_mac } */
-/* { dg-options "-march=rv32i_xcvmac1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvmac -mabi=ilp32" } */
 /* { dg-skip-if "Skip LTO tests of builtin compilation" { *-*-* } { "-flto" } } */
 
 #include <stdint.h>

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-fail-compile-macun.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-fail-compile-macun.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_mac } */
-/* { dg-options "-march=rv32i_xcvmac1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvmac -mabi=ilp32" } */
 /* { dg-skip-if "Skip LTO tests of builtin compilation" { *-*-* } { "-flto" } } */
 
 #include <stdint.h>

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-fail-compile-macurn.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-fail-compile-macurn.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_mac } */
-/* { dg-options "-march=rv32i_xcvmac1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvmac -mabi=ilp32" } */
 /* { dg-skip-if "Skip LTO tests of builtin compilation" { *-*-* } { "-flto" } } */
 
 #include <stdint.h>

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-fail-compile-msu.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-fail-compile-msu.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_mac } */
-/* { dg-options "-march=rv32i_xcvmac1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvmac -mabi=ilp32" } */
 
 #include <stdint.h>
 #include<stdio.h>

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-fail-compile-mulhhsn.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-fail-compile-mulhhsn.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_mac } */
-/* { dg-options "-march=rv32i_xcvmac1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvmac -mabi=ilp32" } */
 /* { dg-skip-if "Skip LTO tests of builtin compilation" { *-*-* } { "-flto" } } */
 
 #include <stdint.h>

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-fail-compile-mulhhsrn.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-fail-compile-mulhhsrn.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_mac } */
-/* { dg-options "-march=rv32i_xcvmac1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvmac -mabi=ilp32" } */
 /* { dg-skip-if "Skip LTO tests of builtin compilation" { *-*-* } { "-flto" } } */
 
 #include <stdint.h>

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-fail-compile-mulhhun.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-fail-compile-mulhhun.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_mac } */
-/* { dg-options "-march=rv32i_xcvmac1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvmac -mabi=ilp32" } */
 /* { dg-skip-if "Skip LTO tests of builtin compilation" { *-*-* } { "-flto" } } */
 
 #include <stdint.h>

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-fail-compile-mulhhurn.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-fail-compile-mulhhurn.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_mac } */
-/* { dg-options "-march=rv32i_xcvmac1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvmac -mabi=ilp32" } */
 /* { dg-skip-if "Skip LTO tests of builtin compilation" { *-*-* } { "-flto" } } */
 
 #include <stdint.h>

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-fail-compile-mulsn.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-fail-compile-mulsn.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_mac } */
-/* { dg-options "-march=rv32i_xcvmac1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvmac -mabi=ilp32" } */
 /* { dg-skip-if "Skip LTO tests of builtin compilation" { *-*-* } { "-flto" } } */
 
 #include <stdint.h>

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-fail-compile-mulsrn.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-fail-compile-mulsrn.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_mac } */
-/* { dg-options "-march=rv32i_xcvmac1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvmac -mabi=ilp32" } */
 /* { dg-skip-if "Skip LTO tests of builtin compilation" { *-*-* } { "-flto" } } */
 
 #include <stdint.h>

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-fail-compile-mulun.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-fail-compile-mulun.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_mac } */
-/* { dg-options "-march=rv32i_xcvmac1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvmac -mabi=ilp32" } */
 /* { dg-skip-if "Skip LTO tests of builtin compilation" { *-*-* } { "-flto" } } */
 
 #include <stdint.h>

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-fail-compile-mulurn.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-fail-compile-mulurn.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_mac } */
-/* { dg-options "-march=rv32i_xcvmac1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvmac -mabi=ilp32" } */
 /* { dg-skip-if "Skip LTO tests of builtin compilation" { *-*-* } { "-flto" } } */
 
 #include <stdint.h>

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-test-autogeneration-mac.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-test-autogeneration-mac.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-O2 -march=rv32im_xcvmac1p0 -mabi=ilp32" } */
+/* { dg-options "-O2 -march=rv32im_xcvmac -mabi=ilp32" } */
 
 int foo(int a, int b, int c)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-test-autogeneration-msu.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvmac-test-autogeneration-msu.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-O2 -march=rv32im_xcvmac1p0 -mabi=ilp32" } */
+/* { dg-options "-O2 -march=rv32im_xcvmac -mabi=ilp32" } */
 
 int foo(int a, int b, int c)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-abs-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-abs-b-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-abs-h-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-abs-h-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-add-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-add-b-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-add-div2-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-add-div2-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-add-div4-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-add-div4-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-add-div8-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-add-div8-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-add-h-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-add-h-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-add-sc-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-add-sc-b-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-add-sc-h-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-add-sc-h-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-and-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-and-b-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-and-h-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-and-h-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-and-sc-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-and-sc-b-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-and-sc-h-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-and-sc-h-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-avg-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-avg-b-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-avg-h-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-avg-h-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-avg-sc-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-avg-sc-b-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-avg-sc-h-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-avg-sc-h-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-avgu-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-avgu-b-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-avgu-h-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-avgu-h-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-avgu-sc-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-avgu-sc-b-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-avgu-sc-h-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-avgu-sc-h-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-cmpeq-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-cmpeq-b-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-cmpeq-h-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-cmpeq-h-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-cmpeq-sc-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-cmpeq-sc-b-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-cmpeq-sc-h-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-cmpeq-sc-h-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-cmpge-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-cmpge-b-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-cmpge-h-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-cmpge-h-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-cmpge-sc-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-cmpge-sc-b-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-cmpge-sc-h-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-cmpge-sc-h-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-cmpgeu-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-cmpgeu-b-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-cmpgeu-h-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-cmpgeu-h-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-cmpgeu-sc-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-cmpgeu-sc-b-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-cmpgeu-sc-h-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-cmpgeu-sc-h-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-cmpgt-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-cmpgt-b-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-cmpgt-h-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-cmpgt-h-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-cmpgt-sc-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-cmpgt-sc-b-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-cmpgt-sc-h-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-cmpgt-sc-h-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-cmpgtu-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-cmpgtu-b-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-cmpgtu-h-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-cmpgtu-h-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-cmpgtu-sc-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-cmpgtu-sc-b-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-cmpgtu-sc-h-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-cmpgtu-sc-h-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-cmple-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-cmple-b-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-cmple-h-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-cmple-h-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-cmple-sc-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-cmple-sc-b-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-cmple-sc-h-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-cmple-sc-h-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-cmpleu-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-cmpleu-b-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-cmpleu-h-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-cmpleu-h-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-cmpleu-sc-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-cmpleu-sc-b-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-cmpleu-sc-h-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-cmpleu-sc-h-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-cmplt-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-cmplt-b-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-cmplt-h-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-cmplt-h-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-cmplt-sc-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-cmplt-sc-b-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-cmplt-sc-h-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-cmplt-sc-h-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-cmpltu-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-cmpltu-b-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-cmpltu-h-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-cmpltu-h-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-cmpltu-sc-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-cmpltu-sc-b-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-cmpltu-sc-h-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-cmpltu-sc-h-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-cmpne-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-cmpne-b-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-cmpne-h-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-cmpne-h-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-cmpne-sc-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-cmpne-sc-b-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-cmpne-sc-h-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-cmpne-sc-h-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-cplxconj-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-cplxconj-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-cplxmul-i-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-cplxmul-i-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b, int c)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-cplxmul-i-div2-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-cplxmul-i-div2-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b, int c)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-cplxmul-i-div4-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-cplxmul-i-div4-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b, int c)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-cplxmul-i-div8-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-cplxmul-i-div8-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b, int c)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-cplxmul-r-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-cplxmul-r-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b, int c)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-cplxmul-r-div2-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-cplxmul-r-div2-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b, int c)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-cplxmul-r-div4-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-cplxmul-r-div4-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b, int c)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-cplxmul-r-div8-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-cplxmul-r-div8-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b, int c)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-dotsp-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-dotsp-b-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-dotsp-h-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-dotsp-h-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-dotsp-sc-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-dotsp-sc-b-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-dotsp-sc-h-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-dotsp-sc-h-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-dotup-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-dotup-b-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-dotup-h-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-dotup-h-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-dotup-sc-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-dotup-sc-b-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-dotup-sc-h-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-dotup-sc-h-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-dotusp-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-dotusp-b-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-dotusp-h-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-dotusp-h-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-dotusp-sc-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-dotusp-sc-b-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-dotusp-sc-h-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-dotusp-sc-h-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-extract-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-extract-b-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-extract-h-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-extract-h-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-extractu-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-extractu-b-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-extractu-h-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-extractu-h-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-insert-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-insert-b-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-insert-h-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-insert-h-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-max-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-max-b-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-max-h-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-max-h-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-max-sc-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-max-sc-b-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-max-sc-h-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-max-sc-h-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-maxu-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-maxu-b-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-maxu-h-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-maxu-h-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-maxu-sc-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-maxu-sc-b-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-maxu-sc-h-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-maxu-sc-h-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-min-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-min-b-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-min-h-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-min-h-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-min-sc-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-min-sc-b-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-min-sc-h-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-min-sc-h-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-minu-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-minu-b-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-minu-h-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-minu-h-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-minu-sc-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-minu-sc-b-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-minu-sc-h-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-minu-sc-h-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-or-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-or-b-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-or-h-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-or-h-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-or-sc-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-or-sc-b-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-or-sc-h-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-or-sc-h-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-pack-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-pack-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-pack-h-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-pack-h-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-packhi-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-packhi-b-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b, int c)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-packlo-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-packlo-b-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b, int c)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-sdotsp-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-sdotsp-b-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b, int c)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-sdotsp-h-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-sdotsp-h-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b, int c)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-sdotsp-sc-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-sdotsp-sc-b-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b, int c)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-sdotsp-sc-h-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-sdotsp-sc-h-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b, int c)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-sdotup-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-sdotup-b-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b, int c)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-sdotup-h-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-sdotup-h-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b, int c)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-sdotup-sc-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-sdotup-sc-b-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b, int c)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-sdotup-sc-h-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-sdotup-sc-h-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b, int c)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-sdotusp-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-sdotusp-b-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b, int c)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-sdotusp-h-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-sdotusp-h-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b, int c)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-sdotusp-sc-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-sdotusp-sc-b-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b, int c)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-sdotusp-sc-h-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-sdotusp-sc-h-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b, int c)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-shuffle-sci-h-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-shuffle-sci-h-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-shuffle2-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-shuffle2-b-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b, int c)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-shuffle2-h-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-shuffle2-h-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b, int c)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-shufflei0-sci-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-shufflei0-sci-b-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-shufflei1-sci-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-shufflei1-sci-b-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-shufflei2-sci-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-shufflei2-sci-b-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-shufflei3-sci-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-shufflei3-sci-b-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-sll-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-sll-b-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-sll-h-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-sll-h-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-sll-sc-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-sll-sc-b-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-sll-sc-h-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-sll-sc-h-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-sra-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-sra-b-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-sra-h-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-sra-h-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-sra-sc-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-sra-sc-b-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-sra-sc-h-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-sra-sc-h-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-srl-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-srl-b-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-srl-h-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-srl-h-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-srl-sc-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-srl-sc-b-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-srl-sc-h-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-srl-sc-h-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-sub-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-sub-b-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-sub-div2-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-sub-div2-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-sub-div4-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-sub-div4-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-sub-div8-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-sub-div8-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-sub-h-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-sub-h-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-sub-sc-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-sub-sc-b-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-sub-sc-h-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-sub-sc-h-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-subrotmj-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-subrotmj-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-subrotmj-div2-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-subrotmj-div2-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-subrotmj-div4-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-subrotmj-div4-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-subrotmj-div8-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-subrotmj-div8-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-xor-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-xor-b-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-xor-h-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-xor-h-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-xor-sc-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-xor-sc-b-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-xor-sc-h-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-xor-sc-h-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 int foo1 (int a, int b)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-xcvsimd-march-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-xcvsimd-march-compile-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_xcvsimd1p0 -mabi=ilp32" } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
 
 int foo1 (int a, int b)

--- a/gcc/testsuite/lib/target-supports.exp
+++ b/gcc/testsuite/lib/target-supports.exp
@@ -12342,7 +12342,7 @@ proc check_effective_target_cv_mac { } {
         {
           asm ("cv.mac t0, t1, t2");
         }
-    } "-march=rv32ixcvmac1p0" ]
+    } "-march=rv32ixcvmac" ]
 }
 
 proc check_effective_target_cv_bitmanip { } {
@@ -12354,7 +12354,7 @@ proc check_effective_target_cv_bitmanip { } {
         {
           asm ("cv.extract t0, t1, 20, 20");
         }
-    } "-march=rv32ixcvbitmanip1p0" ]
+    } "-march=rv32ixcvbitmanip" ]
 }
 
 proc check_effective_target_cv_alu { } {
@@ -12366,5 +12366,5 @@ proc check_effective_target_cv_alu { } {
         {
           asm ("cv.addN t0, t1, t2, 0");
         }
-    } "-march=rv32i_xcvalu1p0" ]
+    } "-march=rv32i_xcvalu" ]
 }


### PR DESCRIPTION
    * gcc/testsuite/gcc.target/riscv/: Updated all XCV tests march string to remove versions.