### PR TITLE
CORE-V: Event Load Builtin Update

### DIFF
--- a/gcc/config/riscv/corev.def
+++ b/gcc/config/riscv/corev.def
@@ -1,5 +1,5 @@
 // XCVELW
-RISCV_BUILTIN (cv_elw_elw_si, "cv_elw_elw", RISCV_BUILTIN_DIRECT, RISCV_USI_FTYPE_INT_PTR, cvelw),
+RISCV_BUILTIN (cv_elw_elw_si, "cv_elw_elw", RISCV_BUILTIN_DIRECT, RISCV_USI_FTYPE_VOID_PTR, cvelw),
 
 // XCVMAC
 RISCV_BUILTIN (cv_mac_mac,       "cv_mac_mac",    RISCV_BUILTIN_DIRECT, RISCV_SI_FTYPE_SI_SI_SI,      cvmac),

--- a/gcc/testsuite/gcc.target/riscv/cv-elw-elw-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-elw-elw-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-options "-march=rv32i_xcvelw1p0 -mabi=ilp32" } */
 
-int foo1(int* b)
+int foo1(void* b)
 {
     return __builtin_riscv_cv_elw_elw(b+8);
 }


### PR DESCRIPTION
    Updated __builtin_riscv_cv_elw_elw to take in a void pointer as an arguement
    to match the builtin specifcation.

    * gcc/config/riscv/corev.def: Changed builtin argument to take a void
      pointer.
    * gcc/testsuite/gcc.target/riscv/cv-elw-elw-compile-1.c: Updated
      builtin test to take in a void pointer.