### PR TITLE
CORE-V: Bit Manipulation bitrev builtin update

### DIFF
--- a/gcc/config/riscv/corev.md
+++ b/gcc/config/riscv/corev.md
@@ -794,7 +794,7 @@
          UNSPEC_CV_BITMANIP_BITREV))]
 
   "TARGET_XCVBITMANIP && !TARGET_64BIT"
-  "cv.bitrev\t%0,%1,%2,%3"
+  "cv.bitrev\t%0,%1,%3,%2"
   [(set_attr "type" "bitmanip")
   (set_attr "mode" "SI")])
 

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-compile-bitrev.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-compile-bitrev.c
@@ -23,8 +23,8 @@ foo (uint32_t a)
   return res1 + res2 + res3 + res4 + res5;
 }
 
-/* { dg-final { scan-assembler-times "cv\.bitrev\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),20,2" 1 } } */
+/* { dg-final { scan-assembler-times "cv\.bitrev\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),2,20" 1 } } */
 /* { dg-final { scan-assembler-times "cv\.bitrev\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),0,0" 1 } } */
-/* { dg-final { scan-assembler-times "cv\.bitrev\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),31,0" 1 } } */
-/* { dg-final { scan-assembler-times "cv\.bitrev\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),0,3" 1 } } */
-/* { dg-final { scan-assembler-times "cv\.bitrev\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),31,3" 1 } } */
+/* { dg-final { scan-assembler-times "cv\.bitrev\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),0,31" 1 } } */
+/* { dg-final { scan-assembler-times "cv\.bitrev\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),3,0" 1 } } */
+/* { dg-final { scan-assembler-times "cv\.bitrev\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),3,31" 1 } } */


### PR DESCRIPTION
    Changed operand order from rd,rs1,Is3,Is2 to
    rd,rs1,Is2,Is3 for cv.bitrev to match the CORE-V
    Builtin Specifcation.

    * gcc/config/riscv/corev.md: Changed operand order for bitrev.
    * gcc/testsuite/gcc.target/riscv/
      cv-march-xcvbitmanip-compile-bitrev.c: Updated dg-final directives
      to match output.