### PR TITLE
CORE-V: Auto-generation for Post-Increment Load & Store Instructions and Register-Register Load & Store Instructions

### DIFF
--- a/gcc/common/config/riscv/riscv-common.cc
+++ b/gcc/common/config/riscv/riscv-common.cc
@@ -246,6 +246,7 @@ static const struct riscv_ext_version riscv_ext_version_table[] =
   {"xcvbitmanip", ISA_SPEC_CLASS_NONE, 1, 0},
   {"xcvsimd", ISA_SPEC_CLASS_NONE, 1, 0},
   {"xcvalu", ISA_SPEC_CLASS_NONE, 1, 0},
+  {"xcvmem", ISA_SPEC_CLASS_NONE, 1, 0},
 
   /* Terminate the list.  */
   {NULL, ISA_SPEC_CLASS_NONE, 0, 0}
@@ -1288,6 +1289,7 @@ static const riscv_ext_flag_table_t riscv_ext_flag_table[] =
   {"xcvsimd", &gcc_options::x_riscv_xcv_flags, MASK_XCVSIMD},
   {"xcvalu", &gcc_options::x_riscv_xcv_flags, MASK_XCVALU},
   {"xcvbi", &gcc_options::x_riscv_xcv_flags, MASK_XCVBI},
+  {"xcvmem", &gcc_options::x_riscv_xcv_flags, MASK_XCVMEM},
 
   {NULL, NULL, 0}
 };

--- a/gcc/config/riscv/corev.md
+++ b/gcc/config/riscv/corev.md
@@ -2839,3 +2839,54 @@
   "cv.b%C1imm\t%2,%3,%0"
   [(set_attr "type" "branch")
    (set_attr "mode" "none")])
+
+;;CORE-V Post Increment Load/ Store
+;; Post Increment Register-Immediate and Register-Register Load/Store
+(define_insn "cv_load<mode>_postinc"
+   [(set (match_operand:ANYI 0 "register_operand" "=r")
+         (match_operand:ANYI 1 "mem_post_inc" "m"))]
+  "TARGET_XCVMEM && riscv_legitimate_post_inc_p (GET_MODE(XEXP(operands[1],0)) , XEXP(operands[1],0), (lra_in_progress || reload_completed))"
+  "cv.<load>\t%0,%1"
+  [(set_attr "type" "load")
+   (set_attr "mode" "<MODE>")])
+
+(define_insn "cv_load_<optab><SHORT:mode>_postinc"
+   [(set (match_operand:SI 0 "register_operand" "=r")
+     (any_extend:SI (match_operand:SHORT 1 "mem_post_inc" "m")))]
+  "TARGET_XCVMEM && riscv_legitimate_post_inc_p (GET_MODE(XEXP(operands[1],0)) , XEXP(operands[1],0), (lra_in_progress || reload_completed))"
+  "cv.<load><u>\t%0,%1"
+  [(set_attr "type" "load")
+   (set_attr "mode" "<MODE>")])
+
+(define_insn "cv_store<mode>_postinc"
+   [(set (match_operand:ANYI 0 "mem_post_inc" "=m")
+     (match_operand:ANYI 1 "register_operand" "r"))]
+  "TARGET_XCVMEM && riscv_legitimate_post_inc_p (GET_MODE(XEXP(operands[0],0)) , XEXP(operands[0],0), (lra_in_progress || reload_completed))"
+  "cv.<store>\t%1,%0"
+  [(set_attr "type" "store")
+   (set_attr "mode" "<MODE>")])
+
+;; Normal Register-Register Load/Store
+(define_insn "cv_load<mode>"
+   [(set (match_operand:ANYI 0 "register_operand" "=r")
+         (match_operand:ANYI 1 "mem_plus_reg" "m"))]
+  "TARGET_XCVMEM && riscv_legitimate_post_inc_p (GET_MODE(XEXP(operands[1],0)) , XEXP(operands[1],0), (lra_in_progress || reload_completed))"
+  "cv.<load>\t%0,%1"
+  [(set_attr "type" "load")
+   (set_attr "mode" "<MODE>")])
+
+(define_insn "cv_load_<optab><SHORT:mode>"
+   [(set (match_operand:SI 0 "register_operand" "=r")
+     (any_extend:SI (match_operand:SHORT 1 "mem_plus_reg" "m")))]
+  "TARGET_XCVMEM && riscv_legitimate_post_inc_p (GET_MODE(XEXP(operands[1],0)) , XEXP(operands[1],0), (lra_in_progress || reload_completed))"
+  "cv.<load><u>\t%0,%1"
+  [(set_attr "type" "load")
+   (set_attr "mode" "<MODE>")])
+
+(define_insn "cv_store<mode>"
+   [(set (match_operand:ANYI 0 "mem_plus_reg" "=m")
+     (match_operand:ANYI 1 "register_operand" "r"))]
+  "TARGET_XCVMEM && riscv_legitimate_post_inc_p (GET_MODE(XEXP(operands[0],0)) , XEXP(operands[0],0), (lra_in_progress || reload_completed))"
+  "cv.<store>\t%1,%0"
+  [(set_attr "type" "store")
+   (set_attr "mode" "<MODE>")])

--- a/gcc/config/riscv/predicates.md
+++ b/gcc/config/riscv/predicates.md
@@ -161,10 +161,26 @@
 	      && riscv_split_symbol_type (symbol_type)
 	      && symbol_type != SYMBOL_PCREL;
 
+    case POST_MODIFY:
+      if (TARGET_XCVMEM)
+	return false;
+
+    case PLUS:
+      if (TARGET_XCVMEM)
+	return false;
+
     default:
       return true;
     }
 })
+
+(define_predicate "mem_post_inc"
+  (and (match_code "mem")
+       (match_test "GET_CODE (XEXP (op,0)) == POST_MODIFY")))
+
+(define_predicate "mem_plus_reg"
+  (and (match_code "mem")
+       (match_test "GET_CODE (XEXP (op,0)) == PLUS")))
 
 (define_predicate "symbolic_operand"
   (match_code "const,symbol_ref,label_ref")

--- a/gcc/config/riscv/riscv-opts.h
+++ b/gcc/config/riscv/riscv-opts.h
@@ -212,6 +212,7 @@ enum stack_protector_guard {
 #define MASK_XCVSIMD            (1 <<  3)
 #define MASK_XCVALU             (1 <<  4)
 #define MASK_XCVBI              (1 <<  5)
+#define MASK_XCVMEM             (1 <<  6)
 
 #define TARGET_XCVELW           ((riscv_xcv_flags & MASK_XCVELW) != 0)
 #define TARGET_XCVMAC           ((riscv_xcv_flags & MASK_XCVMAC) != 0)
@@ -219,5 +220,6 @@ enum stack_protector_guard {
 #define TARGET_XCVSIMD          ((riscv_xcv_flags & MASK_XCVSIMD) != 0)
 #define TARGET_XCVALU           ((riscv_xcv_flags & MASK_XCVALU) != 0)
 #define TARGET_XCVBI            ((riscv_xcv_flags & MASK_XCVBI) != 0)
+#define TARGET_XCVMEM           ((riscv_xcv_flags & MASK_XCVMEM) != 0)
 
 #endif /* ! GCC_RISCV_OPTS_H */

--- a/gcc/config/riscv/riscv-protos.h
+++ b/gcc/config/riscv/riscv-protos.h
@@ -36,6 +36,7 @@ enum riscv_symbol_type {
 #define NUM_SYMBOL_TYPES (SYMBOL_TLS_GD + 1)
 
 /* Routines implemented in riscv.cc.  */
+bool riscv_legitimate_post_inc_p (machine_mode mode, rtx x, bool strict_p);
 extern enum riscv_symbol_type riscv_classify_symbolic_expression (rtx);
 extern bool riscv_symbolic_constant_p (rtx, enum riscv_symbol_type *);
 extern int riscv_regno_mode_ok_for_base_p (int, machine_mode, bool);

--- a/gcc/config/riscv/riscv.h
+++ b/gcc/config/riscv/riscv.h
@@ -536,7 +536,7 @@ enum reg_class
    factor or added to another register (as well as added to a
    displacement).  */
 
-#define INDEX_REG_CLASS NO_REGS
+#define INDEX_REG_CLASS (TARGET_XCVMEM ? GR_REGS : NO_REGS)
 
 /* We generally want to put call-clobbered registers ahead of
    call-saved ones.  (IRA expects this.)  */
@@ -703,6 +703,12 @@ typedef struct {
    ? TRAMPOLINE_CODE_SIZE	\
    : (TRAMPOLINE_CODE_SIZE + POINTER_SIZE * 2))
 #define TRAMPOLINE_ALIGNMENT POINTER_SIZE
+
+/* CORE-V Specific */
+
+#define HAVE_POST_MODIFY_DISP TARGET_XCVMEM
+
+#define HAVE_POST_MODIFY_REG TARGET_XCVMEM
 
 /* Addressing modes, and classification of registers for them.  */
 

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-lb-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-lb-compile-1.c
@@ -1,0 +1,17 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv32i_xcvmem -mabi=ilp32 -fno-unroll-loops" } */
+/* { dg-skip-if "" { *-*-* }  { "-O0" } { "" } } */
+
+int fooQIsigned (signed char* array_char, int n)
+{
+  int char_sum = 1;
+
+  for(int i=0; i<n; i++)
+  {
+    char_sum += array_char[i];
+  }
+
+  return char_sum;
+}
+
+/* { dg-final { scan-assembler-times "cv\\.lb\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),1\\(\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\!\\)" 1 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-lb-compile-2.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-lb-compile-2.c
@@ -1,0 +1,18 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv32i_xcvmem -mabi=ilp32 -fno-unroll-loops" } */
+/* { dg-skip-if "" { *-*-* }  { "-O0" } { "" } } */
+
+int fooQIsigned (signed char* array_char, int n, int j)
+{
+  int char_sum = 1;
+
+  for(int i=0; i<n; i+=j)
+  {
+    char_sum += *array_char;
+    array_char+=j*sizeof(array_char);
+  }
+
+  return char_sum;
+}
+
+/* { dg-final { scan-assembler-times "cv\\.lb\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\(\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\!\\)" 1 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-lb-compile-3.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-lb-compile-3.c
@@ -1,0 +1,10 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv32i_xcvmem -mabi=ilp32 -fno-unroll-loops" } */
+/* { dg-skip-if "" { *-*-* }  { "-O0" } { "" } } */
+
+int fooQIsigned (signed char* array_char, int i, int j)
+{
+  return array_char[i+j];
+}
+
+/* { dg-final { scan-assembler-times "cv\\.lb\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\(\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\)" 1 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-lbu-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-lbu-compile-1.c
@@ -1,0 +1,17 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv32i_xcvmem -mabi=ilp32 -fno-unroll-loops" } */
+/* { dg-skip-if "" { *-*-* }  { "-O0" } { "" } } */
+
+int fooQIunsigned (unsigned char* array_uchar, int n)
+{
+  int uns_char_sum = 1;
+
+  for(int i=0; i<n; i++)
+  {
+    uns_char_sum += array_uchar[i];
+  }
+
+  return uns_char_sum;
+}
+
+/* { dg-final { scan-assembler-times "cv\\.lbu\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),1\\(\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\!\\)" 1 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-lbu-compile-2.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-lbu-compile-2.c
@@ -1,0 +1,18 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv32i_xcvmem -mabi=ilp32 -fno-unroll-loops" } */
+/* { dg-skip-if "" { *-*-* }  { "-O0" } { "" } } */
+
+int fooQIunsigned (unsigned char* array_uchar, int n, int j)
+{
+  int uns_char_sum = 1;
+
+  for(int i=0; i<n; i+=j)
+  {
+    uns_char_sum += *array_uchar;
+    array_uchar+=j*sizeof(array_uchar);
+  }
+
+  return uns_char_sum;
+}
+
+/* { dg-final { scan-assembler-times "cv\\.lbu\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\(\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\!\\)" 1 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-lbu-compile-3.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-lbu-compile-3.c
@@ -1,0 +1,10 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv32i_xcvmem -mabi=ilp32 -fno-unroll-loops" } */
+/* { dg-skip-if "" { *-*-* }  { "-O0" } { "" } } */
+
+int fooQIunsigned (unsigned char* array_uchar, int i, int j)
+{
+  return array_uchar[i+j];
+}
+
+/* { dg-final { scan-assembler-times "cv\\.lbu\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\(\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\)" 1 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-lh-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-lh-compile-1.c
@@ -1,0 +1,17 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv32i_xcvmem -mabi=ilp32 -fno-unroll-loops" } */
+/* { dg-skip-if "" { *-*-* }  { "-O0" } { "" } } */
+
+int fooHIsigned (signed short int* array_short, int n)
+{
+  int short_sum = 1;
+
+  for(int i=0; i<n; i++)
+  {
+    short_sum += array_short[i];
+  }
+
+  return short_sum;
+}
+
+/* { dg-final { scan-assembler-times "cv\\.lh\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),2\\(\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\!\\)" 1 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-lh-compile-2.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-lh-compile-2.c
@@ -1,0 +1,18 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv32i_xcvmem -mabi=ilp32 -fno-unroll-loops" } */
+/* { dg-skip-if "" { *-*-* }  { "-O0" } { "" } } */
+
+int fooHIsigned (signed short int* array_short, int n, int j)
+{
+  int short_sum = 1;
+
+  for(int i=0; i<n; i+=j)
+  {
+    short_sum += *array_short;
+    array_short+=j*sizeof(array_short);
+  }
+
+  return short_sum;
+}
+
+/* { dg-final { scan-assembler-times "cv\\.lh\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\(\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\!\\)" 1 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-lh-compile-3.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-lh-compile-3.c
@@ -1,0 +1,10 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv32i_xcvmem -mabi=ilp32 -fno-unroll-loops" } */
+/* { dg-skip-if "" { *-*-* }  { "-O0" } { "" } } */
+
+int fooHIsigned (signed short int* array_short, int i, int j)
+{
+  return array_short[i+j];
+}
+
+/* { dg-final { scan-assembler-times "cv\\.lh\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\(\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\)" 1 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-lhu-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-lhu-compile-1.c
@@ -1,0 +1,17 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv32i_xcvmem -mabi=ilp32 -fno-unroll-loops" } */
+/* { dg-skip-if "" { *-*-* }  { "-O0" } { "" } } */
+
+int fooHIunsigned (unsigned short int* array_ushort, int n)
+{
+  int uns_short_sum = 1;
+
+  for(int i=0; i<n; i++)
+  {
+    uns_short_sum += array_ushort[i];
+  }
+
+  return uns_short_sum;
+}
+
+/* { dg-final { scan-assembler-times "cv\\.lhu\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),2\\(\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\!\\)" 1 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-lhu-compile-2.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-lhu-compile-2.c
@@ -1,0 +1,18 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv32i_xcvmem -mabi=ilp32 -fno-unroll-loops" } */
+/* { dg-skip-if "" { *-*-* }  { "-O0" } { "" } } */
+
+int fooHIunsigned (unsigned short int* array_ushort, int n, int j)
+{
+  int uns_short_sum = 1;
+
+  for(int i=0; i<n; i+=j)
+  {
+    uns_short_sum += *array_ushort;
+    array_ushort+=j*sizeof(array_ushort);
+  }
+
+  return uns_short_sum;
+}
+
+/* { dg-final { scan-assembler-times "cv\\.lhu\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\(\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\!\\)" 1 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-lhu-compile-3.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-lhu-compile-3.c
@@ -1,0 +1,10 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv32i_xcvmem -mabi=ilp32 -fno-unroll-loops" } */
+/* { dg-skip-if "" { *-*-* }  { "-O0" } { "" } } */
+
+int fooHIunsigned (unsigned short int* array_ushort, int i, int j)
+{
+  return array_ushort[i+j];
+}
+
+/* { dg-final { scan-assembler-times "cv\\.lhu\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\(\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\)" 1 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-lw-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-lw-compile-1.c
@@ -1,0 +1,29 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv32i_xcvmem -mabi=ilp32 -fno-unroll-loops" } */
+/* { dg-skip-if "" { *-*-* }  { "-O0" } { "" } } */
+
+int fooSIsigned (signed int* array_int, int n)
+{
+  int int_sum = 1;
+
+  for(int i=0; i<n; i++)
+  {
+    int_sum += array_int[i];
+  }
+
+  return int_sum;
+}
+
+int fooSIunsigned (unsigned int* array_uint, int n)
+{
+  int uns_int_sum = 1;
+
+  for(int i=0; i<n; i++)
+  {
+    uns_int_sum += array_uint[i];
+  }
+
+  return uns_int_sum;
+}
+
+/* { dg-final { scan-assembler-times "cv\\.lw\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),4\\(\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\!\\)" 2 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-lw-compile-2.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-lw-compile-2.c
@@ -1,0 +1,31 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv32i_xcvmem -mabi=ilp32 -fno-unroll-loops" } */
+/* { dg-skip-if "" { *-*-* }  { "-O0" } { "" } } */
+
+int fooSIsigned (signed int* array_int, int n, int j)
+{
+  int int_sum = 1;
+
+  for(int i=0; i<n; i+=j)
+  {
+    int_sum += *array_int;
+    array_int+=j*sizeof(array_int);
+  }
+
+  return int_sum;
+}
+
+int fooSIunsigned (unsigned int* array_uint, int n, int j)
+{
+  int uns_int_sum = 1;
+
+  for(int i=0; i<n; i+=j)
+  {
+    uns_int_sum += *array_uint;
+    array_uint+=j*sizeof(array_uint);
+  }
+
+  return uns_int_sum;
+}
+
+/* { dg-final { scan-assembler-times "cv\\.lw\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\(\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\!\\)" 2 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-lw-compile-3.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-lw-compile-3.c
@@ -1,0 +1,15 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv32i_xcvmem -mabi=ilp32 -fno-unroll-loops" } */
+/* { dg-skip-if "" { *-*-* }  { "-O0" } { "" } } */
+
+int fooSIsigned (signed int* array_int, int i, int j)
+{
+  return array_int[i+j];
+}
+
+int fooSIunsigned (unsigned int* array_uint, int i, int j)
+{
+  return array_uint[i+j];
+}
+
+/* { dg-final { scan-assembler-times "cv\\.lw\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\(\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\)" 2 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-sb-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-sb-compile-1.c
@@ -1,0 +1,29 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv32i_xcvmem -mabi=ilp32 -fno-unroll-loops -fno-tree-vectorize" } */
+/* { dg-skip-if "" { *-*-* }  { "-O0" } { "" } } */
+
+int fooQIsigned (signed char* array_char, int n)
+{
+  int char_sum = 1;
+
+  for(int i=0; i<n; i++)
+  {
+    array_char[i] += char_sum;
+  }
+
+  return char_sum;
+}
+
+int fooQIunsigned (unsigned char* array_uchar, int n)
+{
+  int uns_char_sum = 1;
+
+  for(int i=0; i<n; i++)
+  {
+    array_uchar[i] += uns_char_sum;
+  }
+
+  return uns_char_sum;
+}
+
+/* { dg-final { scan-assembler-times "cv\\.sb\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),1\\(\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\!\\)" 2 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-sb-compile-2.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-sb-compile-2.c
@@ -1,0 +1,31 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv32i_xcvmem -mabi=ilp32 -fno-unroll-loops -fno-tree-vectorize" } */
+/* { dg-skip-if "" { *-*-* }  { "-O0" } { "" } } */
+
+int fooQIsigned (signed char* array_char, int n, int j)
+{
+  int char_sum = 1;
+
+  for(int i=0; i<n; i+=j)
+  {
+    *array_char += char_sum;
+    array_char+=j*sizeof(array_char);
+  }
+
+  return char_sum;
+}
+
+int fooQIunsigned (unsigned char* array_uchar, int n, int j)
+{
+  int uns_char_sum = 1;
+
+  for(int i=0; i<n; i+=j)
+  {
+    *array_uchar += uns_char_sum;
+    array_uchar+=j*sizeof(array_uchar);
+  }
+
+  return uns_char_sum;
+}
+
+/* { dg-final { scan-assembler-times "cv\\.sb\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\(\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\!\\)" 2 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-sb-compile-3.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-sb-compile-3.c
@@ -1,0 +1,23 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv32i_xcvmem -mabi=ilp32 -fno-unroll-loops -fno-tree-vectorize" } */
+/* { dg-skip-if "" { *-*-* }  { "-O0" } { "" } } */
+
+int fooQIsigned (signed char* array_char, int i, int j)
+{
+  int char_sum = 1;
+
+  array_char[i+j] += char_sum;
+
+  return char_sum;
+}
+
+int fooQIunsigned (unsigned char* array_uchar, int i, int j)
+{
+  int uns_char_sum = 1;
+
+  array_uchar[i+j] += uns_char_sum;
+
+  return uns_char_sum;
+}
+
+/* { dg-final { scan-assembler-times "cv\\.sb\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\(\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\)" 2 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-sh-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-sh-compile-1.c
@@ -1,0 +1,29 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv32i_xcvmem -mabi=ilp32 -fno-unroll-loops" } */
+/* { dg-skip-if "" { *-*-* }  { "-O0" } { "" } } */
+
+int fooHIsigned (signed short int* array_short, int n)
+{
+  int short_sum = 1;
+
+  for(int i=0; i<n; i++)
+  {
+    array_short[i] += short_sum;
+  }
+
+  return short_sum;
+}
+
+int fooHIunsigned (unsigned short int* array_ushort, int n)
+{
+  int uns_short_sum = 1;
+
+  for(int i=0; i<n; i++)
+  {
+    array_ushort[i] += uns_short_sum;
+  }
+
+  return uns_short_sum;
+}
+
+/* { dg-final { scan-assembler-times "cv\\.sh\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),2\\(\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\!\\)" 2 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-sh-compile-2.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-sh-compile-2.c
@@ -1,0 +1,31 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv32i_xcvmem -mabi=ilp32 -fno-unroll-loops" } */
+/* { dg-skip-if "" { *-*-* }  { "-O0" } { "" } } */
+
+int fooHIsigned (signed short int* array_short, int n, int j)
+{
+  int short_sum = 1;
+
+  for(int i=0; i<n; i+=j)
+  {
+    *array_short += short_sum;
+    array_short+=j*sizeof(array_short);
+  }
+
+  return short_sum;
+}
+
+int fooHIunsigned (unsigned short int* array_ushort, int n, int j)
+{
+  int uns_short_sum = 1;
+
+  for(int i=0; i<n; i+=j)
+  {
+    *array_ushort += uns_short_sum;
+    array_ushort+=j*sizeof(array_ushort);
+  }
+
+  return uns_short_sum;
+}
+
+/* { dg-final { scan-assembler-times "cv\\.sh\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\(\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\!\\)" 2 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-sh-compile-3.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-sh-compile-3.c
@@ -1,0 +1,23 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv32i_xcvmem -mabi=ilp32 -fno-unroll-loops" } */
+/* { dg-skip-if "" { *-*-* }  { "-O0" } { "" } } */
+
+int fooHIsigned (signed short int* array_short, int i, int j)
+{
+  int short_sum = 1;
+
+  array_short[i+j] = short_sum;
+
+  return short_sum;
+}
+
+int fooHIunsigned (unsigned short int* array_ushort, int i, int j)
+{
+  int uns_short_sum = 1;
+
+  array_ushort[i+j] += uns_short_sum;
+
+  return uns_short_sum;
+}
+
+/* { dg-final { scan-assembler-times "cv\\.sh\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\(\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\)" 2 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-sw-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-sw-compile-1.c
@@ -1,0 +1,29 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv32i_xcvmem -mabi=ilp32 -fno-unroll-loops" } */
+/* { dg-skip-if "" { *-*-* }  { "-O0" } { "" } } */
+
+int fooSIsigned (signed int* array_int, int n)
+{
+  int int_sum = 1;
+
+  for(int i=0; i<n; i++)
+  {
+    array_int[i] += int_sum;
+  }
+
+  return int_sum;
+}
+
+int fooSIunsigned (unsigned int* array_uint, int n)
+{
+  int uns_int_sum = 1;
+
+  for(int i=0; i<n; i++)
+  {
+    array_uint[i] += uns_int_sum;
+  }
+
+  return uns_int_sum;
+}
+
+/* { dg-final { scan-assembler-times "cv\\.sw\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),4\\(\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\!\\)" 2 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-sw-compile-2.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-sw-compile-2.c
@@ -1,0 +1,31 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv32i_xcvmem -mabi=ilp32 -fno-unroll-loops" } */
+/* { dg-skip-if "" { *-*-* }  { "-O0" } { "" } } */
+
+int fooSIsigned (signed int* array_int, int n, int j)
+{
+  int int_sum = 1;
+
+  for(int i=0; i<n; i+=j)
+  {
+    *array_int += int_sum;
+    array_int+=j*sizeof(array_int);
+  }
+
+  return int_sum;
+}
+
+int fooSIunsigned (unsigned int* array_uint, int n, int j)
+{
+  int uns_int_sum = 1;
+
+  for(int i=0; i<n; i+=j)
+  {
+    *array_uint += uns_int_sum;
+    array_uint+=j*sizeof(array_uint);
+  }
+
+  return uns_int_sum;
+}
+
+/* { dg-final { scan-assembler-times "cv\\.sw\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\(\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\!\\)" 2 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-sw-compile-3.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-sw-compile-3.c
@@ -1,0 +1,23 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv32i_xcvmem -mabi=ilp32 -fno-unroll-loops" } */
+/* { dg-skip-if "" { *-*-* }  { "-O0" } { "" } } */
+
+int fooSIsigned (signed int* array_int, int i, int j)
+{
+  int int_sum = 1;
+
+  array_int[i+j] = int_sum;
+
+  return int_sum;
+}
+
+int fooSIunsigned (unsigned int* array_uint, int i, int j)
+{
+  int uns_int_sum = 1;
+
+  array_uint[i+j] = uns_int_sum;
+
+  return uns_int_sum;
+}
+
+/* { dg-final { scan-assembler-times "cv\\.sw\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\(\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\)" 2 } } */


### PR DESCRIPTION
Post-Increment load and store instructions perform a load, or a store, respectively, while at the same time incrementing the address that was used for the memory access. Since it is a post-incrementing scheme, the base address is used for the access and the modified address is written back to the register-file.

There are versions of those instructions that use immediate and those that use registers as offsets. The base address always comes from a register.
    
* `gcc/common/config/riscv/riscv-common.cc`: Defined `xcvmem` extension.

* gcc/config/riscv/corev.md: Implemented RTL pattern for CORE-V post-inc load/store and reg-reg load/store:
  * `cv_load<mode>_postinc`,
  * `cv_load_<optab><SHORT:mode>_postinc`,
  * `cv_store<mode>_postinc`,
  * `cv_load<mode>`,
  * `cv_load<mode>`,
  * `cv_load_<optab><SHORT:mode>`,
  * `cv_store<mode>`.
    
* `gcc/config/riscv/predicates.md`: Implemented `mem_post_inc` and `mem_plus_reg` predicate and modified `move_operand`.
    
* `gcc/config/riscv/riscv-opts.h`: Created Mask and Target macros for CORE-V post-inc load/store.
    
* `gcc/config/riscv/riscv-protos.h`: Defined `riscv_legitimate_post_inc_p` to verify if post inc instructions are valid.
    
* `gcc/config/riscv/riscv.cc`:
  * Defined and implemented a new RISC-V address type: `ADDRESS_REG_INC`.
  * Implemented a `POST_MODIFY` case in `riscv_classify_address`.
  * Modified the `PLUS` case for reg-reg load/store under `XCVMEM` target.
  * Implemented `riscv_legitimate_post_inc_p`.
  * Modified `riscv_output_move` to include `ADDRESS_REG_INC`
    
* `gcc/config/riscv/riscv.h`: Defined CORE-V Macros for post-inc:
  * `HAVE_POST_MODIFY_DISP`
  * `HAVE_POST_MODIFY_REG`
  * Modified `INDEX_REG_CLASS` to accept `GR_REGS` under `XCVMEM` target.
    
GCC Compilation Tests for
- Post Increment Register-Immediate Load/Store
- Post Increment Register-Register Load/Store
- Regiser-Register Load/Store

All post-increment tests do not support optimisation levels -O0, -Os, -Og, -Oz.

* `gcc/testsuite/gcc.target/riscv/cv-mem-lb-compile-1.c`: Created.
* `gcc/testsuite/gcc.target/riscv/cv-mem-lb-compile-2.c`: Likewise.
* `gcc/testsuite/gcc.target/riscv/cv-mem-lb-compile-3.c`: Likewise.
* `gcc/testsuite/gcc.target/riscv/cv-mem-lbu-compile-1.c`: Likewise.
* `gcc/testsuite/gcc.target/riscv/cv-mem-lbu-compile-2.c`: Likewise.
* `gcc/testsuite/gcc.target/riscv/cv-mem-lbu-compile-3.c`: Likewise.
* `gcc/testsuite/gcc.target/riscv/cv-mem-lh-compile-1.c`: Likewise.
* `gcc/testsuite/gcc.target/riscv/cv-mem-lh-compile-2.c`: Likewise.
* `gcc/testsuite/gcc.target/riscv/cv-mem-lh-compile-3.c`: Likewise.
* `gcc/testsuite/gcc.target/riscv/cv-mem-lhu-compile-1.c`: Likewise.
* `gcc/testsuite/gcc.target/riscv/cv-mem-lhu-compile-2.c`: Likewise.
* `gcc/testsuite/gcc.target/riscv/cv-mem-lhu-compile-3.c`: Likewise.
* `gcc/testsuite/gcc.target/riscv/cv-mem-lw-compile-1.c`: Likewise.
* `gcc/testsuite/gcc.target/riscv/cv-mem-lw-compile-2.c`: Likewise.
* `gcc/testsuite/gcc.target/riscv/cv-mem-lw-compile-3.c`: Likewise.
* `gcc/testsuite/gcc.target/riscv/cv-mem-sb-compile-1.c`: Likewise.
* `gcc/testsuite/gcc.target/riscv/cv-mem-sb-compile-2.c`: Likewise.
* `gcc/testsuite/gcc.target/riscv/cv-mem-sb-compile-3.c`: Likewise.
* `gcc/testsuite/gcc.target/riscv/cv-mem-sh-compile-1.c`: Likewise.
* `gcc/testsuite/gcc.target/riscv/cv-mem-sh-compile-2.c`: Likewise.
* `gcc/testsuite/gcc.target/riscv/cv-mem-sh-compile-3.c`: Likewise.
* `gcc/testsuite/gcc.target/riscv/cv-mem-sw-compile-1.c`: Likewise.
* `gcc/testsuite/gcc.target/riscv/cv-mem-sw-compile-2.c`: Likewise.
* `gcc/testsuite/gcc.target/riscv/cv-mem-sw-compile-3.c`: Likewise.
