### PR TITLE
Fixed operand order for xcvbitmanip instructions

### DIFF
--- a/gcc/config/riscv/corev.md
+++ b/gcc/config/riscv/corev.md
@@ -515,8 +515,8 @@
   {
     int op2_hi = (int)(INTVAL (operands[2]) >> 5);
     int op2_lo = INTVAL (operands[2]) - (op2_hi * 32);
-    rtx t3 = GEN_INT (op2_hi);
-    rtx t4 = GEN_INT (op2_lo);
+    rtx t3 = GEN_INT (op2_lo);
+    rtx t4 = GEN_INT (op2_hi);
     emit_insn (gen_riscv_cv_bitmanip_extract_insn (operands[0], operands[1], t3, t4));
     DONE;
   }
@@ -565,8 +565,8 @@
   {
     int op2_hi = (int)(INTVAL (operands[2]) >> 5);
     int op2_lo = INTVAL (operands[2]) - (op2_hi * 32);
-    rtx t3 = GEN_INT (op2_hi);
-    rtx t4 = GEN_INT (op2_lo);
+    rtx t3 = GEN_INT (op2_lo);
+    rtx t4 = GEN_INT (op2_hi);
     emit_insn (gen_riscv_cv_bitmanip_extractu_insn (operands[0], operands[1], t3, t4));
     DONE;
   }
@@ -620,8 +620,8 @@
     int op2_lo = INTVAL (operands[2]) - (op2_hi * 32);
     if ((op2_hi + op2_lo) >= 32)
       FAIL;
-    rtx t3 = GEN_INT (op2_hi);
-    rtx t4 = GEN_INT (op2_lo);
+    rtx t3 = GEN_INT (op2_lo);
+    rtx t4 = GEN_INT (op2_hi);
     emit_insn (gen_riscv_cv_bitmanip_insert_insn (operands[0], operands[1], t3, t4, operands[3]));
     DONE;
   }

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-compile-extract.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-compile-extract.c
@@ -21,7 +21,7 @@ foo (int32_t a)
   return res1 + res2 + res3 + res4;
 }
 
-/* { dg-final { scan-assembler-times "cv\.extract\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),8,6" 1 } } */
+/* { dg-final { scan-assembler-times "cv\.extract\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),6,8" 1 } } */
 /* { dg-final { scan-assembler-times "cv\.extract\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),0,0" 1 } } */
-/* { dg-final { scan-assembler-times "cv\.extract\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),31,0" 1 } } */
+/* { dg-final { scan-assembler-times "cv\.extract\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),0,31" 1 } } */
 /* { dg-final { scan-assembler-times "cv\.extract\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),31,31" 1 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-compile-extractu.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-compile-extractu.c
@@ -21,7 +21,7 @@ foo (uint32_t a)
   return res1 + res2 + res3 + res4;
 }
 
-/* { dg-final { scan-assembler-times "cv\.extractu\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),8,6" 1 } } */
+/* { dg-final { scan-assembler-times "cv\.extractu\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),6,8" 1 } } */
 /* { dg-final { scan-assembler-times "cv\.extractu\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),0,0" 1 } } */
-/* { dg-final { scan-assembler-times "cv\.extractu\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),31,0" 1 } } */
+/* { dg-final { scan-assembler-times "cv\.extractu\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),0,31" 1 } } */
 /* { dg-final { scan-assembler-times "cv\.extractu\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),31,31" 1 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-compile-insert.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-compile-insert.c
@@ -19,6 +19,6 @@ foo (uint32_t a, uint32_t b)
   return res1 + res2 + res3;
 }
 
-/* { dg-final { scan-assembler-times "cv\.insert\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),8,6" 1 } } */
+/* { dg-final { scan-assembler-times "cv\.insert\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),6,8" 1 } } */
 /* { dg-final { scan-assembler-times "cv\.insert\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),0,0" 1 } } */
-/* { dg-final { scan-assembler-times "cv\.insert\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),31,0" 1 } } */
+/* { dg-final { scan-assembler-times "cv\.insert\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),0,31" 1 } } */


### PR DESCRIPTION
Files Changed:

gcc/config/riscv/

  * corev.md: Changed range operand order.

gcc/testsuite/gcc.target/riscv/

  * cv-march-xcvbitmanip-compile-extract.c: Changed range operand order.
  * cv-march-xcvbitmanip-compile-extractu.c: Likewise.
  * cv-march-xcvbitmanip-compile-insert.c: Likewise.