### PR TITLE
Post inc fixes

### DIFF
--- a/gcc/config/riscv/corev.md
+++ b/gcc/config/riscv/corev.md
@@ -2850,7 +2850,7 @@
 (define_insn "cv_load<mode>_postinc"
    [(set (match_operand:ANYI 0 "register_operand" "=r")
          (match_operand:ANYI 1 "mem_post_inc" "m"))]
-  "TARGET_XCVMEM && riscv_legitimate_post_inc_p (GET_MODE(XEXP(operands[1],0)) , XEXP(operands[1],0), (lra_in_progress || reload_completed))"
+  "TARGET_XCVMEM && riscv_legitimate_xcvmem_address_p (<MODE>mode, XEXP (operands[1], 0), (lra_in_progress || reload_completed))"
   "cv.<load>\t%0,%1"
   [(set_attr "type" "load")
    (set_attr "mode" "<MODE>")])
@@ -2858,7 +2858,7 @@
 (define_insn "cv_load_<optab><SHORT:mode>_postinc"
    [(set (match_operand:SI 0 "register_operand" "=r")
      (any_extend:SI (match_operand:SHORT 1 "mem_post_inc" "m")))]
-  "TARGET_XCVMEM && riscv_legitimate_post_inc_p (GET_MODE(XEXP(operands[1],0)) , XEXP(operands[1],0), (lra_in_progress || reload_completed))"
+  "TARGET_XCVMEM && riscv_legitimate_xcvmem_address_p (<MODE>mode, XEXP (operands[1], 0), (lra_in_progress || reload_completed))"
   "cv.<load><u>\t%0,%1"
   [(set_attr "type" "load")
    (set_attr "mode" "<MODE>")])
@@ -2866,7 +2866,7 @@
 (define_insn "cv_store<mode>_postinc"
    [(set (match_operand:ANYI 0 "mem_post_inc" "=m")
      (match_operand:ANYI 1 "register_operand" "r"))]
-  "TARGET_XCVMEM && riscv_legitimate_post_inc_p (GET_MODE(XEXP(operands[0],0)) , XEXP(operands[0],0), (lra_in_progress || reload_completed))"
+  "TARGET_XCVMEM && riscv_legitimate_xcvmem_address_p (<MODE>mode, XEXP (operands[0], 0), (lra_in_progress || reload_completed))"
   "cv.<store>\t%1,%0"
   [(set_attr "type" "store")
    (set_attr "mode" "<MODE>")])
@@ -2875,7 +2875,7 @@
 (define_insn "cv_load<mode>"
    [(set (match_operand:ANYI 0 "register_operand" "=r")
          (match_operand:ANYI 1 "mem_plus_reg" "m"))]
-  "TARGET_XCVMEM && riscv_legitimate_post_inc_p (GET_MODE(XEXP(operands[1],0)) , XEXP(operands[1],0), (lra_in_progress || reload_completed))"
+  "TARGET_XCVMEM && riscv_legitimate_xcvmem_address_p (<MODE>mode, XEXP (operands[1], 0), (lra_in_progress || reload_completed))"
   "cv.<load>\t%0,%1"
   [(set_attr "type" "load")
    (set_attr "mode" "<MODE>")])
@@ -2883,7 +2883,7 @@
 (define_insn "cv_load_<optab><SHORT:mode>"
    [(set (match_operand:SI 0 "register_operand" "=r")
      (any_extend:SI (match_operand:SHORT 1 "mem_plus_reg" "m")))]
-  "TARGET_XCVMEM && riscv_legitimate_post_inc_p (GET_MODE(XEXP(operands[1],0)) , XEXP(operands[1],0), (lra_in_progress || reload_completed))"
+  "TARGET_XCVMEM && riscv_legitimate_xcvmem_address_p (<MODE>mode, XEXP (operands[1], 0), (lra_in_progress || reload_completed))"
   "cv.<load><u>\t%0,%1"
   [(set_attr "type" "load")
    (set_attr "mode" "<MODE>")])
@@ -2891,7 +2891,7 @@
 (define_insn "cv_store<mode>"
    [(set (match_operand:ANYI 0 "mem_plus_reg" "=m")
      (match_operand:ANYI 1 "register_operand" "r"))]
-  "TARGET_XCVMEM && riscv_legitimate_post_inc_p (GET_MODE(XEXP(operands[0],0)) , XEXP(operands[0],0), (lra_in_progress || reload_completed))"
+  "TARGET_XCVMEM && riscv_legitimate_xcvmem_address_p (<MODE>mode, XEXP (operands[0], 0), (lra_in_progress || reload_completed))"
   "cv.<store>\t%1,%0"
   [(set_attr "type" "store")
    (set_attr "mode" "<MODE>")])

--- a/gcc/config/riscv/predicates.md
+++ b/gcc/config/riscv/predicates.md
@@ -104,8 +104,19 @@
   return false;
 })
 
+(define_predicate "mem_post_inc"
+  (and (match_code "mem")
+       (match_test "TARGET_XCVMEM && GET_CODE (XEXP (op, 0)) == POST_MODIFY")))
+
+(define_predicate "mem_plus_reg"
+  (and (match_code "mem")
+       (match_test "TARGET_XCVMEM && GET_CODE (XEXP (op, 0)) == PLUS
+		    && REG_P (XEXP (XEXP (op, 0), 1))")))
+
 (define_predicate "move_operand"
-  (match_operand 0 "general_operand")
+  (and (match_operand 0 "general_operand")
+  (and (not (match_operand 0 "mem_post_inc"))
+       (not (match_operand 0 "mem_plus_reg"))))
 {
   enum riscv_symbol_type symbol_type;
 
@@ -161,26 +172,10 @@
 	      && riscv_split_symbol_type (symbol_type)
 	      && symbol_type != SYMBOL_PCREL;
 
-    case POST_MODIFY:
-      if (TARGET_XCVMEM)
-	return false;
-
-    case PLUS:
-      if (TARGET_XCVMEM)
-	return false;
-
     default:
       return true;
     }
 })
-
-(define_predicate "mem_post_inc"
-  (and (match_code "mem")
-       (match_test "GET_CODE (XEXP (op,0)) == POST_MODIFY")))
-
-(define_predicate "mem_plus_reg"
-  (and (match_code "mem")
-       (match_test "GET_CODE (XEXP (op,0)) == PLUS")))
 
 (define_predicate "symbolic_operand"
   (match_code "const,symbol_ref,label_ref")

--- a/gcc/config/riscv/riscv-protos.h
+++ b/gcc/config/riscv/riscv-protos.h
@@ -36,7 +36,7 @@ enum riscv_symbol_type {
 #define NUM_SYMBOL_TYPES (SYMBOL_TLS_GD + 1)
 
 /* Routines implemented in riscv.cc.  */
-bool riscv_legitimate_post_inc_p (machine_mode mode, rtx x, bool strict_p);
+bool riscv_legitimate_xcvmem_address_p (machine_mode, rtx, bool);
 extern enum riscv_symbol_type riscv_classify_symbolic_expression (rtx);
 extern bool riscv_symbolic_constant_p (rtx, enum riscv_symbol_type *);
 extern int riscv_regno_mode_ok_for_base_p (int, machine_mode, bool);

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-lw-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-lw-compile-1.c
@@ -2,6 +2,10 @@
 /* { dg-options "-march=rv32i_xcvmem -mabi=ilp32 -fno-unroll-loops" } */
 /* { dg-skip-if "" { *-*-* }  { "-O0" } { "" } } */
 
+/*
+ * Test for post-inc register-immediate loads.
+ */
+
 int fooSIsigned (signed int* array_int, int n)
 {
   int int_sum = 1;

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-lw-compile-2.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-lw-compile-2.c
@@ -2,6 +2,10 @@
 /* { dg-options "-march=rv32i_xcvmem -mabi=ilp32 -fno-unroll-loops" } */
 /* { dg-skip-if "" { *-*-* }  { "-O0" } { "" } } */
 
+/*
+ * Test for post-inc register-register loads.
+ */
+
 int fooSIsigned (signed int* array_int, int n, int j)
 {
   int int_sum = 1;

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-lw-compile-3.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-lw-compile-3.c
@@ -2,6 +2,10 @@
 /* { dg-options "-march=rv32i_xcvmem -mabi=ilp32 -fno-unroll-loops" } */
 /* { dg-skip-if "" { *-*-* }  { "-O0" } { "" } } */
 
+/*
+ * Test for normal register-register loads.
+ */
+
 int fooSIsigned (signed int* array_int, int i, int j)
 {
   return array_int[i+j];

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-lw-compile-4.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-lw-compile-4.c
@@ -1,0 +1,19 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv32i_xcvmem -mabi=ilp32 -fno-unroll-loops" } */
+/* { dg-skip-if "" { *-*-* }  { "-O0" } { "" } } */
+
+/*
+ * Test for illegal normal register-immediate loads.
+ */
+
+int fooSIsigned (signed int* array_int)
+{
+  return array_int [3];
+}
+
+int fooSIunsigned (unsigned int* array_uint)
+{
+  return array_uint [3];
+}
+
+/* { dg-final { scan-assembler-not "cv\\.lw\t" } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-sw-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-sw-compile-1.c
@@ -2,6 +2,10 @@
 /* { dg-options "-march=rv32i_xcvmem -mabi=ilp32 -fno-unroll-loops" } */
 /* { dg-skip-if "" { *-*-* }  { "-O0" } { "" } } */
 
+/*
+ * Test for post-inc register-immediate saves.
+ */
+
 int fooSIsigned (signed int* array_int, int n)
 {
   int int_sum = 1;

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-sw-compile-2.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-sw-compile-2.c
@@ -2,6 +2,10 @@
 /* { dg-options "-march=rv32i_xcvmem -mabi=ilp32 -fno-unroll-loops" } */
 /* { dg-skip-if "" { *-*-* }  { "-O0" } { "" } } */
 
+/*
+ * Test for post-inc register-register saves.
+ */
+
 int fooSIsigned (signed int* array_int, int n, int j)
 {
   int int_sum = 1;

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-sw-compile-3.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-sw-compile-3.c
@@ -2,6 +2,10 @@
 /* { dg-options "-march=rv32i_xcvmem -mabi=ilp32 -fno-unroll-loops" } */
 /* { dg-skip-if "" { *-*-* }  { "-O0" } { "" } } */
 
+/*
+ * Test for normal register-register saves.
+ */
+
 int fooSIsigned (signed int* array_int, int i, int j)
 {
   int int_sum = 1;

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-sw-compile-4.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-sw-compile-4.c
@@ -1,0 +1,21 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv32i_xcvmem -mabi=ilp32 -fno-unroll-loops" } */
+/* { dg-skip-if "" { *-*-* }  { "-O0" } { "" } } */
+
+/*
+ * Test for illegal normal register-immediate saves.
+ */
+
+int fooSIsigned (signed int* array_int, int i)
+{
+  array_int [3] = i;
+  return array_int [3];
+}
+
+int fooSIunsigned (unsigned int* array_uint, int i)
+{
+  array_uint [3] = i;
+  return array_uint [3];
+}
+
+/* { dg-final { scan-assembler-not "cv\\.sw\t" } } */


### PR DESCRIPTION
Added ```GET_CODE (XEXP (XEXP (op, 0), 1) == REG``` to ensure no register to immediate normal load/stores.

Files Changed:

  * gcc/config/riscv/corev.md: Tidy up.
  * gcc/config/riscv/riscv-protos.h: Likewise.
  * gcc/config/riscv/predicates.md: Ensure no register to immediate normal load/stores.
  * gcc/config/riscv/riscv.cc: Likewise.
  * gcc/testsuite/gcc.target/riscv/cv-mem-lw-compile-4.c: Added new test to check for illegal corev register to immediate load/ stores.
  * gcc/testsuite/gcc.target/riscv/cv-mem-sw-compile-4.c: Likewise.