### PR TITLE
Name change for post inc operands

### DIFF
--- a/gcc/config/riscv/riscv.cc
+++ b/gcc/config/riscv/riscv.cc
@@ -4660,8 +4660,8 @@ riscv_print_operand_address (FILE *file, machine_mode mode ATTRIBUTE_UNUSED, rtx
 	return;
 
       case ADDRESS_REG_INC:
+	fprintf (file, "(%s),", reg_names[REGNO (addr.reg)]);
 	riscv_print_operand (file, addr.offset, 0);
-	fprintf (file, "(%s!)", reg_names[REGNO (addr.reg)]);
 	return;
       }
   gcc_unreachable ();

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-lb-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-lb-compile-1.c
@@ -14,4 +14,4 @@ int fooQIsigned (signed char* array_char, int n)
   return char_sum;
 }
 
-/* { dg-final { scan-assembler-times "cv\\.lb\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),1\\(\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\!\\)" 1 } } */
+/* { dg-final { scan-assembler-times "cv\\.lb\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\\(\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\),1" 1 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-lb-compile-2.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-lb-compile-2.c
@@ -15,4 +15,4 @@ int fooQIsigned (signed char* array_char, int n, int j)
   return char_sum;
 }
 
-/* { dg-final { scan-assembler-times "cv\\.lb\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\(\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\!\\)" 1 } } */
+/* { dg-final { scan-assembler-times "cv\\.lb\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\\(\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)" 1 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-lbu-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-lbu-compile-1.c
@@ -14,4 +14,4 @@ int fooQIunsigned (unsigned char* array_uchar, int n)
   return uns_char_sum;
 }
 
-/* { dg-final { scan-assembler-times "cv\\.lbu\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),1\\(\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\!\\)" 1 } } */
+/* { dg-final { scan-assembler-times "cv\\.lbu\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\\(\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\),1" 1 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-lbu-compile-2.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-lbu-compile-2.c
@@ -15,4 +15,4 @@ int fooQIunsigned (unsigned char* array_uchar, int n, int j)
   return uns_char_sum;
 }
 
-/* { dg-final { scan-assembler-times "cv\\.lbu\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\(\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\!\\)" 1 } } */
+/* { dg-final { scan-assembler-times "cv\\.lbu\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\\(\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)" 1 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-lh-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-lh-compile-1.c
@@ -14,4 +14,4 @@ int fooHIsigned (signed short int* array_short, int n)
   return short_sum;
 }
 
-/* { dg-final { scan-assembler-times "cv\\.lh\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),2\\(\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\!\\)" 1 } } */
+/* { dg-final { scan-assembler-times "cv\\.lh\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\\(\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\),2" 1 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-lh-compile-2.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-lh-compile-2.c
@@ -15,4 +15,4 @@ int fooHIsigned (signed short int* array_short, int n, int j)
   return short_sum;
 }
 
-/* { dg-final { scan-assembler-times "cv\\.lh\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\(\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\!\\)" 1 } } */
+/* { dg-final { scan-assembler-times "cv\\.lh\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\\(\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)" 1 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-lhu-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-lhu-compile-1.c
@@ -14,4 +14,4 @@ int fooHIunsigned (unsigned short int* array_ushort, int n)
   return uns_short_sum;
 }
 
-/* { dg-final { scan-assembler-times "cv\\.lhu\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),2\\(\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\!\\)" 1 } } */
+/* { dg-final { scan-assembler-times "cv\\.lhu\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\\(\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\),2" 1 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-lhu-compile-2.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-lhu-compile-2.c
@@ -15,4 +15,4 @@ int fooHIunsigned (unsigned short int* array_ushort, int n, int j)
   return uns_short_sum;
 }
 
-/* { dg-final { scan-assembler-times "cv\\.lhu\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\(\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\!\\)" 1 } } */
+/* { dg-final { scan-assembler-times "cv\\.lhu\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\\(\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)" 1 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-lw-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-lw-compile-1.c
@@ -30,4 +30,4 @@ int fooSIunsigned (unsigned int* array_uint, int n)
   return uns_int_sum;
 }
 
-/* { dg-final { scan-assembler-times "cv\\.lw\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),4\\(\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\!\\)" 2 } } */
+/* { dg-final { scan-assembler-times "cv\\.lw\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\\(\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\),4" 2 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-lw-compile-2.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-lw-compile-2.c
@@ -32,4 +32,4 @@ int fooSIunsigned (unsigned int* array_uint, int n, int j)
   return uns_int_sum;
 }
 
-/* { dg-final { scan-assembler-times "cv\\.lw\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\(\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\!\\)" 2 } } */
+/* { dg-final { scan-assembler-times "cv\\.lw\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\\(\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)" 2 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-sb-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-sb-compile-1.c
@@ -26,4 +26,4 @@ int fooQIunsigned (unsigned char* array_uchar, int n)
   return uns_char_sum;
 }
 
-/* { dg-final { scan-assembler-times "cv\\.sb\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),1\\(\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\!\\)" 2 } } */
+/* { dg-final { scan-assembler-times "cv\\.sb\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\\(\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\),1" 2 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-sb-compile-2.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-sb-compile-2.c
@@ -28,4 +28,4 @@ int fooQIunsigned (unsigned char* array_uchar, int n, int j)
   return uns_char_sum;
 }
 
-/* { dg-final { scan-assembler-times "cv\\.sb\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\(\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\!\\)" 2 } } */
+/* { dg-final { scan-assembler-times "cv\\.sb\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\\(\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)" 2 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-sh-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-sh-compile-1.c
@@ -26,4 +26,4 @@ int fooHIunsigned (unsigned short int* array_ushort, int n)
   return uns_short_sum;
 }
 
-/* { dg-final { scan-assembler-times "cv\\.sh\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),2\\(\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\!\\)" 2 } } */
+/* { dg-final { scan-assembler-times "cv\\.sh\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\\(\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\),2" 2 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-sh-compile-2.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-sh-compile-2.c
@@ -28,4 +28,4 @@ int fooHIunsigned (unsigned short int* array_ushort, int n, int j)
   return uns_short_sum;
 }
 
-/* { dg-final { scan-assembler-times "cv\\.sh\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\(\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\!\\)" 2 } } */
+/* { dg-final { scan-assembler-times "cv\\.sh\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\\(\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)" 2 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-sw-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-sw-compile-1.c
@@ -30,4 +30,4 @@ int fooSIunsigned (unsigned int* array_uint, int n)
   return uns_int_sum;
 }
 
-/* { dg-final { scan-assembler-times "cv\\.sw\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),4\\(\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\!\\)" 2 } } */
+/* { dg-final { scan-assembler-times "cv\\.sw\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\\(\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\),4" 2 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-sw-compile-2.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-sw-compile-2.c
@@ -32,4 +32,4 @@ int fooSIunsigned (unsigned int* array_uint, int n, int j)
   return uns_int_sum;
 }
 
-/* { dg-final { scan-assembler-times "cv\\.sw\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\(\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\!\\)" 2 } } */
+/* { dg-final { scan-assembler-times "cv\\.sw\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\\(\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)" 2 } } */


### PR DESCRIPTION
Issue [#60](https://github.com/openhwgroup/corev-gcc/issues/60)

Files Changed:

  * config/riscv/riscv.cc: Name change for post inc operands.
  * testsuite/gcc.target/riscv/cv-mem-lb-compile-1.c: Likewise.
  * testsuite/gcc.target/riscv/cv-mem-lb-compile-2.c: Likewise.
  * testsuite/gcc.target/riscv/cv-mem-lbu-compile-1.c: Likewise.
  * testsuite/gcc.target/riscv/cv-mem-lbu-compile-2.c: Likewise.
  * testsuite/gcc.target/riscv/cv-mem-lh-compile-1.c: Likewise.
  * testsuite/gcc.target/riscv/cv-mem-lh-compile-2.c: Likewise.
  * testsuite/gcc.target/riscv/cv-mem-lhu-compile-1.c: Likewise.
  * testsuite/gcc.target/riscv/cv-mem-lhu-compile-2.c: Likewise.
  * testsuite/gcc.target/riscv/cv-mem-lw-compile-1.c: Likewise.
  * testsuite/gcc.target/riscv/cv-mem-lw-compile-2.c: Likewise.
  * testsuite/gcc.target/riscv/cv-mem-sb-compile-1.c: Likewise.
  * testsuite/gcc.target/riscv/cv-mem-sb-compile-2.c: Likewise.
  * testsuite/gcc.target/riscv/cv-mem-sh-compile-1.c: Likewise.
  * testsuite/gcc.target/riscv/cv-mem-sh-compile-2.c: Likewise.
  * testsuite/gcc.target/riscv/cv-mem-sw-compile-1.c: Likewise.
  * testsuite/gcc.target/riscv/cv-mem-sw-compile-2.c: Likewise.