### PR TITLE
Added __builtin_riscv_cv_simd_neg_[h,b]

### DIFF
--- a/gcc/config/riscv/corev.def
+++ b/gcc/config/riscv/corev.def
@@ -94,6 +94,8 @@ RISCV_BUILTIN (cv_simd_and_sc_h_si,		"cv_simd_and_sc_h",	RISCV_BUILTIN_DIRECT, R
 RISCV_BUILTIN (cv_simd_and_sc_b_si,		"cv_simd_and_sc_b",	RISCV_BUILTIN_DIRECT, RISCV_USI_FTYPE_USI_QI, 		cvsimd),
 RISCV_BUILTIN (cv_simd_abs_h_si,		"cv_simd_abs_h",	RISCV_BUILTIN_DIRECT, RISCV_USI_FTYPE_USI, 		cvsimd),
 RISCV_BUILTIN (cv_simd_abs_b_si,		"cv_simd_abs_b",	RISCV_BUILTIN_DIRECT, RISCV_USI_FTYPE_USI, 		cvsimd),
+RISCV_BUILTIN (cv_simd_neg_h_si,                "cv_simd_neg_h",        RISCV_BUILTIN_DIRECT, RISCV_USI_FTYPE_USI,              cvsimd),
+RISCV_BUILTIN (cv_simd_neg_b_si,                "cv_simd_neg_b",        RISCV_BUILTIN_DIRECT, RISCV_USI_FTYPE_USI,              cvsimd),
 //BIT MANIPULATION
 RISCV_BUILTIN (cv_simd_extract_h_si,		"cv_simd_extract_h",	RISCV_BUILTIN_DIRECT, RISCV_USI_FTYPE_USI_QI, 		cvsimd),
 RISCV_BUILTIN (cv_simd_extract_b_si,		"cv_simd_extract_b",	RISCV_BUILTIN_DIRECT, RISCV_USI_FTYPE_USI_QI, 		cvsimd),

--- a/gcc/config/riscv/corev.md
+++ b/gcc/config/riscv/corev.md
@@ -101,6 +101,8 @@
   UNSPEC_CV_AND_SC_B
   UNSPEC_CV_ABS_H
   UNSPEC_CV_ABS_B
+  UNSPEC_CV_NEG_H
+  UNSPEC_CV_NEG_B
 
   ;;CORE-V SIMD BIT MANIPULATION
   UNSPEC_CV_EXTRACT_H
@@ -1498,6 +1500,24 @@
 	"cv.abs.b\\t%0,%1"
 	[(set_attr "type" "arith")
 	(set_attr "mode" "SI")])
+
+
+(define_insn "riscv_cv_simd_neg_h_si"
+        [(set (match_operand:SI 0 "register_operand" "=r")
+                (unspec:SI [(match_operand:SI 1 "register_operand" "r")]UNSPEC_CV_NEG_H))]
+        "TARGET_XCVSIMD && !TARGET_64BIT"
+        "cv.sub.h\\t%0,zero,%1"
+        [(set_attr "type" "arith")
+        (set_attr "mode" "SI")])
+
+
+(define_insn "riscv_cv_simd_neg_b_si"
+        [(set (match_operand:SI 0 "register_operand" "=r")
+                (unspec:SI [(match_operand:SI 1 "register_operand" "r")]UNSPEC_CV_NEG_B))]
+        "TARGET_XCVSIMD && !TARGET_64BIT"
+        "cv.sub.b\\t%0,zero,%1"
+        [(set_attr "type" "arith")
+        (set_attr "mode" "SI")])
 
 
 ;;CORE-V SIMD BIT MANIPULATION

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-neg-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-neg-b-compile-1.c
@@ -1,0 +1,9 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
+
+int foo1 (int a)
+{
+	return __builtin_riscv_cv_simd_neg_b(a);
+}
+
+/* { dg-final { scan-assembler-times "cv\\.sub\\.b" 1 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-neg-h-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-neg-h-compile-1.c
@@ -1,0 +1,9 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
+
+int foo1 (int a)
+{
+	return __builtin_riscv_cv_simd_neg_h(a);
+}
+
+/* { dg-final { scan-assembler-times "cv\\.sub\\.h" 1 } } */


### PR DESCRIPTION
Issue [#54](https://github.com/openhwgroup/corev-gcc/issues/54) CORE-V: SIMD __builtin_riscv_cv_simd_neg_h and __builtin_riscv_cv_simd_neg_b needs implementing

Files Changed:

  * config/riscv/corev.def: Added new builtins.
  * config/riscv/corev.md: Likewise.
  * testsuite/gcc.target/riscv/cv-simd-neg-b-compile-1.c: Created.
  * testsuite/gcc.target/riscv/cv-simd-neg-h-compile-1.c: Likewise.