### PR TITLE
Prevent non-xcvmem post-inc load/stores

### DIFF
--- a/gcc/config/riscv/corev.md
+++ b/gcc/config/riscv/corev.md
@@ -2883,13 +2883,101 @@
   [(set_attr "type" "load")
    (set_attr "mode" "<MODE>")])
 
+(define_insn "cv_loadsf_postinc_hardfloat"
+   [(set (match_operand:SF 0 "register_operand" "=r")
+         (match_operand:SF 1 "mem_post_inc" "m"))]
+  "TARGET_HARD_FLOAT && TARGET_XCVMEM
+   && riscv_legitimate_xcvmem_address_p (SFmode, XEXP (operands[1], 0), (lra_in_progress || reload_completed))
+   && (register_operand (operands[0], SFmode)
+       || reg_or_0_operand (operands[1], SFmode))"
+  "cv.lw\t%0,%1"
+  [(set_attr "type" "load")
+   (set_attr "mode" "SF")])
+
+(define_insn "cv_loadsf_postinc_softfloat"
+   [(set (match_operand:SF 0 "register_operand" "=r")
+         (match_operand:SF 1 "mem_post_inc" "m"))]
+  "!TARGET_HARD_FLOAT && TARGET_XCVMEM
+   && riscv_legitimate_xcvmem_address_p (SFmode, XEXP (operands[1], 0), (lra_in_progress || reload_completed))
+   && (register_operand (operands[0], SFmode)
+       || reg_or_0_operand (operands[1], SFmode))"
+  "cv.lw\t%0,%1"
+  [(set_attr "type" "load")
+   (set_attr "mode" "SF")])
+
+(define_insn "cv_loadhf_postinc_hardfloat"
+   [(set (match_operand:HF 0 "register_operand" "=r")
+         (match_operand:HF 1 "mem_post_inc" "m"))]
+  "TARGET_HARD_FLOAT && TARGET_XCVMEM
+   && riscv_legitimate_xcvmem_address_p (HFmode, XEXP (operands[1], 0), (lra_in_progress || reload_completed))
+   && (register_operand (operands[0], HFmode)
+       || reg_or_0_operand (operands[1], HFmode))"
+  "cv.lh\t%0,%1"
+  [(set_attr "type" "load")
+   (set_attr "mode" "HF")])
+
+(define_insn "cv_loadhf_postinc_softfloat"
+   [(set (match_operand:HF 0 "register_operand" "=r")
+         (match_operand:HF 1 "mem_post_inc" "m"))]
+  "!TARGET_HARD_FLOAT && TARGET_XCVMEM
+   && riscv_legitimate_xcvmem_address_p (HFmode, XEXP (operands[1], 0), (lra_in_progress || reload_completed))
+   && (register_operand (operands[0], HFmode)
+       || reg_or_0_operand (operands[1], HFmode))"
+  "cv.lh\t%0,%1"
+  [(set_attr "type" "load")
+   (set_attr "mode" "HF")])
+
 (define_insn "cv_store<mode>_postinc"
    [(set (match_operand:ANYI 0 "mem_post_inc" "=m")
-     (match_operand:ANYI 1 "register_operand" "r"))]
+         (match_operand:ANYI 1 "register_operand" "r"))]
   "TARGET_XCVMEM && riscv_legitimate_xcvmem_address_p (<MODE>mode, XEXP (operands[0], 0), (lra_in_progress || reload_completed))"
   "cv.<store>\t%1,%0"
   [(set_attr "type" "store")
    (set_attr "mode" "<MODE>")])
+
+(define_insn "cv_storesf_postinc_hardfloat"
+   [(set (match_operand:SF 0 "mem_post_inc" "=m")
+         (match_operand:SF 1 "register_operand" "r"))]
+  "TARGET_HARD_FLOAT && TARGET_XCVMEM
+   && riscv_legitimate_xcvmem_address_p (SFmode, XEXP (operands[0], 0), (lra_in_progress || reload_completed))
+   && (register_operand (operands[0], SFmode)
+       || reg_or_0_operand (operands[1], SFmode))"
+  "cv.sw\t%1,%0"
+  [(set_attr "type" "store")
+   (set_attr "mode" "SF")])
+
+(define_insn "cv_storesf_postinc_softfloat"
+   [(set (match_operand:SF 0 "mem_post_inc" "=m")
+         (match_operand:SF 1 "register_operand" "r"))]
+  "!TARGET_HARD_FLOAT && TARGET_XCVMEM
+   && riscv_legitimate_xcvmem_address_p (SFmode, XEXP (operands[0], 0), (lra_in_progress || reload_completed))
+   && (register_operand (operands[0], SFmode)
+       || reg_or_0_operand (operands[1], SFmode))"
+  "cv.sw\t%1,%0"
+  [(set_attr "type" "store")
+   (set_attr "mode" "SF")])
+
+(define_insn "cv_storehf_postinc_hardfloat"
+   [(set (match_operand:HF 0 "mem_post_inc" "=m")
+         (match_operand:HF 1 "register_operand" "r"))]
+  "TARGET_HARD_FLOAT && TARGET_XCVMEM
+   && riscv_legitimate_xcvmem_address_p (HFmode, XEXP (operands[0], 0), (lra_in_progress || reload_completed))
+   && (register_operand (operands[0], HFmode)
+       || reg_or_0_operand (operands[1], HFmode))"
+  "cv.sh\t%1,%0"
+  [(set_attr "type" "store")
+   (set_attr "mode" "HF")])
+
+(define_insn "cv_storehf_postinc_softfloat"
+   [(set (match_operand:HF 0 "mem_post_inc" "=m")
+         (match_operand:HF 1 "register_operand" "r"))]
+  "!TARGET_HARD_FLOAT && TARGET_XCVMEM
+   && riscv_legitimate_xcvmem_address_p (HFmode, XEXP (operands[0], 0), (lra_in_progress || reload_completed))
+   && (register_operand (operands[0], HFmode)
+       || reg_or_0_operand (operands[1], HFmode))"
+  "cv.sh\t%1,%0"
+  [(set_attr "type" "store")
+   (set_attr "mode" "HF")])
 
 ;; Normal Register-Register Load/Store
 (define_insn "cv_load<mode>"
@@ -2908,6 +2996,50 @@
   [(set_attr "type" "load")
    (set_attr "mode" "<MODE>")])
 
+(define_insn "cv_loadsf_hardfloat"
+   [(set (match_operand:SF 0 "register_operand" "=r")
+         (match_operand:SF 1 "mem_plus_reg" "m"))]
+  "TARGET_HARD_FLOAT && TARGET_XCVMEM
+   && riscv_legitimate_xcvmem_address_p (SFmode, XEXP (operands[1], 0), (lra_in_progress || reload_completed))
+   && (register_operand (operands[0], SFmode)
+       || reg_or_0_operand (operands[1], SFmode))"
+  "cv.lw\t%0,%1"
+  [(set_attr "type" "load")
+   (set_attr "mode" "SF")])
+
+(define_insn "cv_loadsf_softfloat"
+   [(set (match_operand:SF 0 "register_operand" "=r")
+         (match_operand:SF 1 "mem_plus_reg" "m"))]
+  "!TARGET_HARD_FLOAT && TARGET_XCVMEM
+   && riscv_legitimate_xcvmem_address_p (SFmode, XEXP (operands[1], 0), (lra_in_progress || reload_completed))
+   && (register_operand (operands[0], SFmode)
+       || reg_or_0_operand (operands[1], SFmode))"
+  "cv.lw\t%0,%1"
+  [(set_attr "type" "load")
+   (set_attr "mode" "SF")])
+
+(define_insn "cv_loadhf_hardfloat"
+   [(set (match_operand:HF 0 "register_operand" "=r")
+         (match_operand:HF 1 "mem_plus_reg" "m"))]
+  "TARGET_HARD_FLOAT && TARGET_XCVMEM
+   && riscv_legitimate_xcvmem_address_p (HFmode, XEXP (operands[1], 0), (lra_in_progress || reload_completed))
+   && (register_operand (operands[0], HFmode)
+       || reg_or_0_operand (operands[1], HFmode))"
+  "cv.lh\t%0,%1"
+  [(set_attr "type" "load")
+   (set_attr "mode" "HF")])
+
+(define_insn "cv_loadhf_softfloat"
+   [(set (match_operand:HF 0 "register_operand" "=r")
+         (match_operand:HF 1 "mem_plus_reg" "m"))]
+  "!TARGET_HARD_FLOAT && TARGET_XCVMEM
+   && riscv_legitimate_xcvmem_address_p (HFmode, XEXP (operands[1], 0), (lra_in_progress || reload_completed))
+   && (register_operand (operands[0], HFmode)
+       || reg_or_0_operand (operands[1], HFmode))"
+  "cv.lh\t%0,%1"
+  [(set_attr "type" "load")
+   (set_attr "mode" "HF")])
+
 (define_insn "cv_store<mode>"
    [(set (match_operand:ANYI 0 "mem_plus_reg" "=m")
      (match_operand:ANYI 1 "register_operand" "r"))]
@@ -2915,3 +3047,47 @@
   "cv.<store>\t%1,%0"
   [(set_attr "type" "store")
    (set_attr "mode" "<MODE>")])
+
+(define_insn "cv_storesf_hardfloat"
+  [(set (match_operand:SF 0 "mem_plus_reg"     "=m")
+        (match_operand:SF 1 "register_operand" " r"))]
+  "TARGET_HARD_FLOAT && TARGET_XCVMEM
+   && riscv_legitimate_xcvmem_address_p (SFmode, XEXP (operands[0], 0), (lra_in_progress || reload_completed))
+   && (register_operand (operands[0], SFmode)
+       || reg_or_0_operand (operands[1], SFmode))"
+  "cv.sw\t%1,%0"
+  [(set_attr "move_type" "store")
+   (set_attr "mode" "SF")])
+
+(define_insn "cv_storesf_softfloat"
+  [(set (match_operand:SF 0 "mem_plus_reg"     "=m")
+        (match_operand:SF 1 "register_operand" " r"))]
+  "!TARGET_HARD_FLOAT && TARGET_XCVMEM
+   && riscv_legitimate_xcvmem_address_p (SFmode, XEXP (operands[0], 0), (lra_in_progress || reload_completed))
+   && (register_operand (operands[0], SFmode)
+       || reg_or_0_operand (operands[1], SFmode))"
+  "cv.sw\t%1,%0"
+  [(set_attr "move_type" "store")
+   (set_attr "mode" "SF")])
+
+(define_insn "cv_storehf_hardfloat"
+  [(set (match_operand:HF 0 "mem_plus_reg"     "=m")
+        (match_operand:HF 1 "register_operand" " r"))]
+  "TARGET_HARD_FLOAT && TARGET_XCVMEM
+   && riscv_legitimate_xcvmem_address_p (HFmode, XEXP (operands[0], 0), (lra_in_progress || reload_completed))
+   && (register_operand (operands[0], HFmode)
+       || reg_or_0_operand (operands[1], HFmode))"
+  "cv.sh\t%1,%0"
+  [(set_attr "move_type" "store")
+   (set_attr "mode" "HF")])
+
+(define_insn "cv_storehf_softfloat"
+  [(set (match_operand:HF 0 "mem_plus_reg"     "=m")
+        (match_operand:HF 1 "register_operand" " r"))]
+  "!TARGET_HARD_FLOAT && TARGET_XCVMEM
+   && riscv_legitimate_xcvmem_address_p (HFmode, XEXP (operands[0], 0), (lra_in_progress || reload_completed))
+   && (register_operand (operands[0], HFmode)
+       || reg_or_0_operand (operands[1], HFmode))"
+  "cv.sh\t%1,%0"
+  [(set_attr "move_type" "store")
+   (set_attr "mode" "HF")])

--- a/gcc/config/riscv/predicates.md
+++ b/gcc/config/riscv/predicates.md
@@ -320,6 +320,11 @@
   (and (match_code "const_int")
        (match_test "IN_RANGE (INTVAL (op), -16, 15)")))
 
+(define_predicate "nonimmediate_nonpostinc"
+  (and (match_operand 0 "nonimmediate_operand")
+	(and (not (match_operand 0 "mem_post_inc"))
+	     (not (match_operand 0 "mem_plus_reg")))))
+
 
 ;; Predicates for the V extension.
 (define_special_predicate "vector_length_operand"

--- a/gcc/config/riscv/riscv.cc
+++ b/gcc/config/riscv/riscv.cc
@@ -1087,7 +1087,7 @@ riscv_classify_address (struct riscv_address_info *info, rtx x,
       info->offset = XEXP (x, 1);
       return (riscv_valid_base_register_p (info->reg, mode, strict_p)
 	      && (riscv_valid_offset_p (info->offset, mode)
-		  || TARGET_XCVMEM && riscv_valid_base_register_p (info->offset, mode, strict_p)));
+		  || (TARGET_XCVMEM && riscv_valid_base_register_p (info->offset, mode, strict_p))));
 
     case LO_SUM:
       /* RVV load/store disallow LO_SUM.  */

--- a/gcc/config/riscv/riscv.md
+++ b/gcc/config/riscv/riscv.md
@@ -1367,13 +1367,13 @@
 
 (define_expand "zero_extendsidi2"
   [(set (match_operand:DI 0 "register_operand")
-	(zero_extend:DI (match_operand:SI 1 "nonimmediate_operand")))]
+	(zero_extend:DI (match_operand:SI 1 "nonimmediate_nonpostinc")))]
   "TARGET_64BIT")
 
 (define_insn_and_split "*zero_extendsidi2_internal"
   [(set (match_operand:DI     0 "register_operand"     "=r,r")
 	(zero_extend:DI
-	    (match_operand:SI 1 "nonimmediate_operand" " r,m")))]
+	    (match_operand:SI 1 "nonimmediate_nonpostinc" " r,m")))]
   "TARGET_64BIT && !TARGET_ZBA
    && !(REG_P (operands[1])
         && REGNO (operands[1]) == VL_REGNUM)"
@@ -1394,13 +1394,13 @@
 (define_expand "zero_extendhi<GPR:mode>2"
   [(set (match_operand:GPR    0 "register_operand")
 	(zero_extend:GPR
-	    (match_operand:HI 1 "nonimmediate_operand")))]
+	    (match_operand:HI 1 "nonimmediate_nonpostinc")))]
   "")
 
 (define_insn_and_split "*zero_extendhi<GPR:mode>2"
   [(set (match_operand:GPR    0 "register_operand"     "=r,r")
 	(zero_extend:GPR
-	    (match_operand:HI 1 "nonimmediate_operand" " r,m")))]
+	    (match_operand:HI 1 "nonimmediate_nonpostinc" " r,m")))]
   "!TARGET_ZBB"
   "@
    #
@@ -1422,7 +1422,7 @@
 (define_insn "zero_extendqi<SUPERQI:mode>2"
   [(set (match_operand:SUPERQI 0 "register_operand"    "=r,r")
 	(zero_extend:SUPERQI
-	    (match_operand:QI 1 "nonimmediate_operand" " r,m")))]
+	    (match_operand:QI 1 "nonimmediate_nonpostinc" " r,m")))]
   ""
   "@
    andi\t%0,%1,0xff
@@ -1440,7 +1440,7 @@
 (define_insn "extendsidi2"
   [(set (match_operand:DI     0 "register_operand"     "=r,r")
 	(sign_extend:DI
-	    (match_operand:SI 1 "nonimmediate_operand" " r,m")))]
+	    (match_operand:SI 1 "nonimmediate_nonpostinc" " r,m")))]
   "TARGET_64BIT"
   "@
    sext.w\t%0,%1
@@ -1450,13 +1450,13 @@
 
 (define_expand "extend<SHORT:mode><SUPERQI:mode>2"
   [(set (match_operand:SUPERQI 0 "register_operand")
-	(sign_extend:SUPERQI (match_operand:SHORT 1 "nonimmediate_operand")))]
+	(sign_extend:SUPERQI (match_operand:SHORT 1 "nonimmediate_nonpostinc")))]
   "")
 
 (define_insn_and_split "*extend<SHORT:mode><SUPERQI:mode>2"
   [(set (match_operand:SUPERQI   0 "register_operand"     "=r,r")
 	(sign_extend:SUPERQI
-	    (match_operand:SHORT 1 "nonimmediate_operand" " r,m")))]
+	    (match_operand:SHORT 1 "nonimmediate_nonpostinc" " r,m")))]
   "!TARGET_ZBB"
   "@
    #
@@ -1514,7 +1514,7 @@
 })
 
 (define_insn "*movhf_hardfloat"
-  [(set (match_operand:HF 0 "nonimmediate_operand" "=f,f,f,m,m,*f,*r,  *r,*r,*m")
+  [(set (match_operand:HF 0 "nonimmediate_nonpostinc" "=f,f,f,m,m,*f,*r,  *r,*r,*m")
 	(match_operand:HF 1 "move_operand"         " f,G,m,f,G,*r,*f,*G*r,*m,*r"))]
   "TARGET_ZFHMIN
    && (register_operand (operands[0], HFmode)
@@ -1524,7 +1524,7 @@
    (set_attr "mode" "HF")])
 
 (define_insn "*movhf_softfloat"
-  [(set (match_operand:HF 0 "nonimmediate_operand" "=f, r,r,m,*f,*r")
+  [(set (match_operand:HF 0 "nonimmediate_nonpostinc" "=f, r,r,m,*f,*r")
 	(match_operand:HF 1 "move_operand"         " f,Gr,m,r,*r,*f"))]
   "!TARGET_ZFHMIN
    && (register_operand (operands[0], HFmode)
@@ -1720,7 +1720,7 @@
 })
 
 (define_insn "*movdi_32bit"
-  [(set (match_operand:DI 0 "nonimmediate_operand" "=r,r,r,m,  *f,*f,*r,*f,*m,r")
+  [(set (match_operand:DI 0 "nonimmediate_nonpostinc" "=r,r,r,m,  *f,*f,*r,*f,*m,r")
 	(match_operand:DI 1 "move_operand"         " r,i,m,r,*J*r,*m,*f,*f,*f,vp"))]
   "!TARGET_64BIT
    && (register_operand (operands[0], DImode)
@@ -1731,7 +1731,7 @@
    (set_attr "ext" "base,base,base,base,d,d,d,d,d,vector")])
 
 (define_insn "*movdi_64bit"
-  [(set (match_operand:DI 0 "nonimmediate_operand" "=r,r,r, m,  *f,*f,*r,*f,*m,r")
+  [(set (match_operand:DI 0 "nonimmediate_nonpostinc" "=r,r,r, m,  *f,*f,*r,*f,*m,r")
 	(match_operand:DI 1 "move_operand"         " r,T,m,rJ,*r*J,*m,*f,*f,*f,vp"))]
   "TARGET_64BIT
    && (register_operand (operands[0], DImode)
@@ -1753,8 +1753,8 @@
 })
 
 (define_insn "*movsi_internal"
-  [(set (match_operand:SI 0 "nonimmediate_operand" "=r,r,r, m,  *f,*f,*r,*m,r")
-	(match_operand:SI 1 "move_operand"         " r,T,m,rJ,*r*J,*m,*f,*f,vp"))]
+  [(set (match_operand:SI 0 "nonimmediate_nonpostinc" "=r,r,r, m,  *f,*f,*r,*m,r")
+	(match_operand:SI 1 "move_operand"            " r,T,m,rJ,*r*J,*m,*f,*f,vp"))]
   "(register_operand (operands[0], SImode)
     || reg_or_0_operand (operands[1], SImode))
     && !(register_operand (operands[1], SImode)
@@ -1781,8 +1781,8 @@
 })
 
 (define_insn "*movhi_internal"
-  [(set (match_operand:HI 0 "nonimmediate_operand" "=r,r,r, m,  *f,*r,r")
-	(match_operand:HI 1 "move_operand"	   " r,T,m,rJ,*r*J,*f,vp"))]
+  [(set (match_operand:HI 0 "nonimmediate_nonpostinc" "=r,r,r, m,  *f,*r,r")
+	(match_operand:HI 1 "move_operand"	      " r,T,m,rJ,*r*J,*f,vp"))]
   "(register_operand (operands[0], HImode)
     || reg_or_0_operand (operands[1], HImode))"
   { return riscv_output_move (operands[0], operands[1]); }
@@ -1824,8 +1824,8 @@
 })
 
 (define_insn "*movqi_internal"
-  [(set (match_operand:QI 0 "nonimmediate_operand" "=r,r,r, m,  *f,*r,r")
-	(match_operand:QI 1 "move_operand"         " r,I,m,rJ,*r*J,*f,vp"))]
+  [(set (match_operand:QI 0 "nonimmediate_nonpostinc" "=r,r,r, m,  *f,*r,r")
+	(match_operand:QI 1 "move_operand"            " r,I,m,rJ,*r*J,*f,vp"))]
   "(register_operand (operands[0], QImode)
     || reg_or_0_operand (operands[1], QImode))"
   { return riscv_output_move (operands[0], operands[1]); }
@@ -1845,7 +1845,7 @@
 })
 
 (define_insn "*movsf_hardfloat"
-  [(set (match_operand:SF 0 "nonimmediate_operand" "=f,f,f,m,m,*f,*r,  *r,*r,*m")
+  [(set (match_operand:SF 0 "nonimmediate_nonpostinc" "=f,f,f,m,m,*f,*r,  *r,*r,*m")
 	(match_operand:SF 1 "move_operand"         " f,G,m,f,G,*r,*f,*G*r,*m,*r"))]
   "TARGET_HARD_FLOAT
    && (register_operand (operands[0], SFmode)
@@ -1855,7 +1855,7 @@
    (set_attr "mode" "SF")])
 
 (define_insn "*movsf_softfloat"
-  [(set (match_operand:SF 0 "nonimmediate_operand" "= r,r,m")
+  [(set (match_operand:SF 0 "nonimmediate_nonpostinc" "= r,r,m")
 	(match_operand:SF 1 "move_operand"         " Gr,m,r"))]
   "!TARGET_HARD_FLOAT
    && (register_operand (operands[0], SFmode)
@@ -1878,7 +1878,7 @@
 ;; In RV32, we lack fmv.x.d and fmv.d.x.  Go through memory instead.
 ;; (However, we can still use fcvt.d.w to zero a floating-point register.)
 (define_insn "*movdf_hardfloat_rv32"
-  [(set (match_operand:DF 0 "nonimmediate_operand" "=f,f,f,m,m,  *r,*r,*m")
+  [(set (match_operand:DF 0 "nonimmediate_nonpostinc" "=f,f,f,m,m,  *r,*r,*m")
 	(match_operand:DF 1 "move_operand"         " f,G,m,f,G,*r*G,*m,*r"))]
   "!TARGET_64BIT && TARGET_DOUBLE_FLOAT
    && (register_operand (operands[0], DFmode)
@@ -1888,7 +1888,7 @@
    (set_attr "mode" "DF")])
 
 (define_insn "*movdf_hardfloat_rv64"
-  [(set (match_operand:DF 0 "nonimmediate_operand" "=f,f,f,m,m,*f,*r,  *r,*r,*m")
+  [(set (match_operand:DF 0 "nonimmediate_nonpostinc" "=f,f,f,m,m,*f,*r,  *r,*r,*m")
 	(match_operand:DF 1 "move_operand"         " f,G,m,f,G,*r,*f,*r*G,*m,*r"))]
   "TARGET_64BIT && TARGET_DOUBLE_FLOAT
    && (register_operand (operands[0], DFmode)
@@ -1898,7 +1898,7 @@
    (set_attr "mode" "DF")])
 
 (define_insn "*movdf_softfloat"
-  [(set (match_operand:DF 0 "nonimmediate_operand" "= r,r, m")
+  [(set (match_operand:DF 0 "nonimmediate_nonpostinc" "= r,r, m")
 	(match_operand:DF 1 "move_operand"         " rG,m,rG"))]
   "!TARGET_DOUBLE_FLOAT
    && (register_operand (operands[0], DFmode)
@@ -1908,7 +1908,7 @@
    (set_attr "mode" "DF")])
 
 (define_split
-  [(set (match_operand:MOVE64 0 "nonimmediate_operand")
+  [(set (match_operand:MOVE64 0 "nonimmediate_nonpostinc")
 	(match_operand:MOVE64 1 "move_operand"))]
   "reload_completed
    && riscv_split_64bit_move_p (operands[0], operands[1])"

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-sw-compile-5.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-sw-compile-5.c
@@ -1,0 +1,13 @@
+/* { dg-do assemble } */
+/* { dg-options "-march=rv32i_xcvmem" } */
+
+int a;
+float *b;
+
+int
+foo (void)
+{
+  int c;
+  for (c = 0; c < 10; c++)
+    b[c] = a;
+}


### PR DESCRIPTION
Issue [#64]

Files Changed:

  * config/riscv/corev.md: Added support for soft/hardfloat normal and post-inc reg-reg load/stores.
  * config/riscv/predicates.md: Added predicate to check if operand is non-immediate and non-post-inc.
  * config/riscv/riscv.md: Likewise.
  * config/riscv/riscv.cc: Clean up.
  * testsuite/gcc.target/riscv/cv-mem-sw-compile-5.c: New test.