### PR TITLE
Fixes to xcvbitmanip and xcvsimd

### DIFF
--- a/gcc/config/riscv/corev.md
+++ b/gcc/config/riscv/corev.md
@@ -672,8 +672,8 @@
   {
     int op2_hi = (int)(INTVAL (operands[2]) >> 5);
     int op2_lo = INTVAL (operands[2]) - (op2_hi * 32);
-    rtx t3 = GEN_INT (op2_hi);
-    rtx t4 = GEN_INT (op2_lo);
+    rtx t3 = GEN_INT (op2_lo);
+    rtx t4 = GEN_INT (op2_hi);
     emit_insn (gen_riscv_cv_bitmanip_bclr_insn (operands[0], operands[1], t3, t4));
     DONE;
   }
@@ -722,8 +722,8 @@
   {
     int op2_hi = (int)(INTVAL (operands[2]) >> 5);
     int op2_lo = INTVAL (operands[2]) - (op2_hi * 32);
-    rtx t3 = GEN_INT (op2_hi);
-    rtx t4 = GEN_INT (op2_lo);
+    rtx t3 = GEN_INT (op2_lo);
+    rtx t4 = GEN_INT (op2_hi);
     emit_insn (gen_riscv_cv_bitmanip_bset_insn (operands[0], operands[1], t3, t4));
     DONE;
   }
@@ -1221,7 +1221,7 @@
 (define_insn "riscv_cv_simd_srl_sc_h_si"
 	[(set (match_operand:SI 0 "register_operand" "=r,r")
 		(unspec:SI [(match_operand:SI 1 "register_operand" "r,r")
-		(match_operand:HI 2 "int6s_operand" "CV6,r")]
+		(match_operand:HI 2 "int6_operand" "CS6,r")]
 	UNSPEC_CV_SRL_SC_H))]
 	"TARGET_XCVSIMD && !TARGET_64BIT"
 	"@
@@ -1234,7 +1234,7 @@
 (define_insn "riscv_cv_simd_srl_sc_b_si"
 	[(set (match_operand:SI 0 "register_operand" "=r,r")
 		(unspec:SI [(match_operand:SI 1 "register_operand" "r,r")
-		(match_operand:QI 2 "int6s_operand" "CV6,r")]
+		(match_operand:QI 2 "int6_operand" "CS6,r")]
 	UNSPEC_CV_SRL_SC_B))]
 	"TARGET_XCVSIMD && !TARGET_64BIT"
 	"@
@@ -1269,7 +1269,7 @@
 (define_insn "riscv_cv_simd_sra_sc_h_si"
 	[(set (match_operand:SI 0 "register_operand" "=r,r")
 		(unspec:SI [(match_operand:SI 1 "register_operand" "r,r")
-		(match_operand:HI 2 "int6s_operand" "CV6,r")]
+		(match_operand:HI 2 "int6_operand" "CS6,r")]
 	UNSPEC_CV_SRA_SC_H))]
 	"TARGET_XCVSIMD && !TARGET_64BIT"
 	"@
@@ -1282,7 +1282,7 @@
 (define_insn "riscv_cv_simd_sra_sc_b_si"
 	[(set (match_operand:SI 0 "register_operand" "=r,r")
 		(unspec:SI [(match_operand:SI 1 "register_operand" "r,r")
-		(match_operand:QI 2 "int6s_operand" "CV6,r")]
+		(match_operand:QI 2 "int6_operand" "CS6,r")]
 	UNSPEC_CV_SRA_SC_B))]
 	"TARGET_XCVSIMD && !TARGET_64BIT"
 	"@
@@ -1317,7 +1317,7 @@
 (define_insn "riscv_cv_simd_sll_sc_h_si"
 	[(set (match_operand:SI 0 "register_operand" "=r,r")
 		(unspec:SI [(match_operand:SI 1 "register_operand" "r,r")
-		(match_operand:HI 2 "int6s_operand" "CV6,r")]
+		(match_operand:HI 2 "int6_operand" "CS6,r")]
 	UNSPEC_CV_SLL_SC_H))]
 	"TARGET_XCVSIMD && !TARGET_64BIT"
 	"@
@@ -1330,7 +1330,7 @@
 (define_insn "riscv_cv_simd_sll_sc_b_si"
 	[(set (match_operand:SI 0 "register_operand" "=r,r")
 		(unspec:SI [(match_operand:SI 1 "register_operand" "r,r")
-		(match_operand:QI 2 "int6s_operand" "CV6,r")]
+		(match_operand:QI 2 "int6_operand" "CS6,r")]
 	UNSPEC_CV_SLL_SC_B))]
 	"TARGET_XCVSIMD && !TARGET_64BIT"
 	"@

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-compile-bclr.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-compile-bclr.c
@@ -21,7 +21,7 @@ foo (uint32_t a)
   return res1 + res2 + res3 + res4;
 }
 
-/* { dg-final { scan-assembler-times "cv\.bclr\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),8,6" 1 } } */
+/* { dg-final { scan-assembler-times "cv\.bclr\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),6,8" 1 } } */
 /* { dg-final { scan-assembler-times "cv\.bclr\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),0,0" 1 } } */
-/* { dg-final { scan-assembler-times "cv\.bclr\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),31,0" 1 } } */
+/* { dg-final { scan-assembler-times "cv\.bclr\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),0,31" 1 } } */
 /* { dg-final { scan-assembler-times "cv\.bclr\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),31,31" 1 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-compile-bset.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvbitmanip-compile-bset.c
@@ -21,7 +21,7 @@ foo (uint32_t a)
   return res1 + res2 + res3 + res4;
 }
 
-/* { dg-final { scan-assembler-times "cv\.bset\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),8,6" 1 } } */
+/* { dg-final { scan-assembler-times "cv\.bset\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),6,8" 1 } } */
 /* { dg-final { scan-assembler-times "cv\.bset\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),0,0" 1 } } */
-/* { dg-final { scan-assembler-times "cv\.bset\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),31,0" 1 } } */
+/* { dg-final { scan-assembler-times "cv\.bset\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),0,31" 1 } } */
 /* { dg-final { scan-assembler-times "cv\.bset\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),31,31" 1 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-extract-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-extract-b-compile-1.c
@@ -1,19 +1,22 @@
 /* { dg-do compile } */
 /* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
-int foo1 (int a)
+int
+foo1 (int a)
 {
-	return __builtin_riscv_cv_simd_extract_b(a, -32);
+	return __builtin_riscv_cv_simd_extract_b (a, 0);
 }
 
-int foo2 (int a)
+int
+foo2 (int a)
 {
-	return __builtin_riscv_cv_simd_extract_b(a, 0);
+	return __builtin_riscv_cv_simd_extract_b (a, 3);
 }
 
-int foo3 (int a)
+int
+foo3 (int a)
 {
-	return __builtin_riscv_cv_simd_extract_b(a, 31);
+	return __builtin_riscv_cv_simd_extract_b (a, 255);
 }
 
 /* { dg-final { scan-assembler-times "cv\\.extract\\.b" 3 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-extract-h-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-extract-h-compile-1.c
@@ -1,19 +1,22 @@
 /* { dg-do compile } */
 /* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
-int foo1 (int a)
+int
+foo1 (int a)
 {
-	return __builtin_riscv_cv_simd_extract_h(a, -32);
+	return __builtin_riscv_cv_simd_extract_h (a, 0);
 }
 
-int foo2 (int a)
+int
+foo2 (int a)
 {
-	return __builtin_riscv_cv_simd_extract_h(a, 0);
+	return __builtin_riscv_cv_simd_extract_h (a, 1);
 }
 
-int foo3 (int a)
+int
+foo3 (int a)
 {
-	return __builtin_riscv_cv_simd_extract_h(a, 31);
+        return __builtin_riscv_cv_simd_extract_h (a, 255);
 }
 
 /* { dg-final { scan-assembler-times "cv\\.extract\\.h" 3 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-extractu-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-extractu-b-compile-1.c
@@ -1,19 +1,22 @@
 /* { dg-do compile } */
 /* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
-int foo1 (int a)
+int
+foo1 (int a)
 {
-	return __builtin_riscv_cv_simd_extractu_b(a, -32);
+	return __builtin_riscv_cv_simd_extractu_b (a, 0);
 }
 
-int foo2 (int a)
+int
+foo2 (int a)
 {
-	return __builtin_riscv_cv_simd_extractu_b(a, 0);
+	return __builtin_riscv_cv_simd_extractu_b (a, 3);
 }
 
-int foo3 (int a)
+int
+foo3 (int a)
 {
-	return __builtin_riscv_cv_simd_extractu_b(a, 31);
+	return __builtin_riscv_cv_simd_extractu_b (a, 255);
 }
 
 /* { dg-final { scan-assembler-times "cv\\.extractu\\.b" 3 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-extractu-h-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-extractu-h-compile-1.c
@@ -1,19 +1,22 @@
 /* { dg-do compile } */
 /* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
-int foo1 (int a)
+int
+foo1 (int a)
 {
-	return __builtin_riscv_cv_simd_extractu_h(a, -32);
+	return __builtin_riscv_cv_simd_extractu_h (a, 0);
 }
 
-int foo2 (int a)
+int
+foo2 (int a)
 {
-	return __builtin_riscv_cv_simd_extractu_h(a, 0);
+	return __builtin_riscv_cv_simd_extractu_h (a, 1);
 }
 
-int foo3 (int a)
+int
+foo3 (int a)
 {
-	return __builtin_riscv_cv_simd_extractu_h(a, 31);
+	return __builtin_riscv_cv_simd_extractu_h (a, 255);
 }
 
 /* { dg-final { scan-assembler-times "cv\\.extractu\\.h" 3 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-insert-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-insert-b-compile-1.c
@@ -1,19 +1,22 @@
 /* { dg-do compile } */
 /* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
-int foo1 (int a, int b)
+int
+foo1 (int a, int b)
 {
-	return __builtin_riscv_cv_simd_insert_b(a, b, -32);
+	return __builtin_riscv_cv_simd_insert_b (a, b, 0);
 }
 
-int foo2 (int a, int b)
+int
+foo2 (int a, int b)
 {
-	return __builtin_riscv_cv_simd_insert_b(a, b, 0);
+	return __builtin_riscv_cv_simd_insert_b (a, b, 3);
 }
 
-int foo3 (int a, int b)
+int
+foo3 (int a, int b)
 {
-	return __builtin_riscv_cv_simd_insert_b(a, b, 31);
+	return __builtin_riscv_cv_simd_insert_b (a, b, 255);
 }
 
 /* { dg-final { scan-assembler-times "cv\\.insert\\.b" 3 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-insert-h-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-insert-h-compile-1.c
@@ -1,19 +1,22 @@
 /* { dg-do compile } */
 /* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
-int foo1 (int a, int b)
+int
+foo1 (int a, int b)
 {
-	return __builtin_riscv_cv_simd_insert_h(a, b, -32);
+	return __builtin_riscv_cv_simd_insert_h (a, b, 0);
 }
 
-int foo2 (int a, int b)
+int
+foo2 (int a, int b)
 {
-	return __builtin_riscv_cv_simd_insert_h(a, b, 0);
+	return __builtin_riscv_cv_simd_insert_h (a, b, 1);
 }
 
-int foo3 (int a, int b)
+int
+foo3 (int a, int b)
 {
-	return __builtin_riscv_cv_simd_insert_h(a, b, 31);
+	return __builtin_riscv_cv_simd_insert_h (a, b, 255);
 }
 
 /* { dg-final { scan-assembler-times "cv\\.insert\\.h" 3 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-sll-sc-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-sll-sc-b-compile-1.c
@@ -1,25 +1,23 @@
 /* { dg-do compile } */
 /* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
-int foo1 (int a, int b)
+int
+foo1 (int a, int b)
 {
-	return __builtin_riscv_cv_simd_sll_sc_b(a, b);
+	return __builtin_riscv_cv_simd_sll_sc_b (a, b);
 }
 
-int foo2 (int a)
+int
+foo2 (int a)
 {
-	return __builtin_riscv_cv_simd_sll_sc_b(a, -32);
+	return __builtin_riscv_cv_simd_sll_sc_b (a, 0);
 }
 
-int foo3 (int a)
+int
+foo3 (int a)
 {
-	return __builtin_riscv_cv_simd_sll_sc_b(a, 0);
-}
-
-int foo4 (int a)
-{
-	return __builtin_riscv_cv_simd_sll_sc_b(a, 31);
+	return __builtin_riscv_cv_simd_sll_sc_b (a, 63);
 }
 
 /* { dg-final { scan-assembler-times "cv\\.sll\\.sc\\.b" 1 } } */
-/* { dg-final { scan-assembler-times "cv\\.sll\\.sci\\.b" 3 } } */
+/* { dg-final { scan-assembler-times "cv\\.sll\\.sci\\.b" 2 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-sll-sc-h-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-sll-sc-h-compile-1.c
@@ -1,25 +1,23 @@
 /* { dg-do compile } */
 /* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
-int foo1 (int a, int b)
+int
+foo1 (int a, int b)
 {
-	return __builtin_riscv_cv_simd_sll_sc_h(a, b);
+	return __builtin_riscv_cv_simd_sll_sc_h (a, b);
 }
 
-int foo2 (int a)
+int
+foo2 (int a)
 {
-	return __builtin_riscv_cv_simd_sll_sc_h(a, -32);
+	return __builtin_riscv_cv_simd_sll_sc_h (a, 0);
 }
 
-int foo3 (int a)
+int
+foo3 (int a)
 {
-	return __builtin_riscv_cv_simd_sll_sc_h(a, 0);
-}
-
-int foo4 (int a)
-{
-	return __builtin_riscv_cv_simd_sll_sc_h(a, 31);
+	return __builtin_riscv_cv_simd_sll_sc_h (a, 63);
 }
 
 /* { dg-final { scan-assembler-times "cv\\.sll\\.sc\\.h" 1 } } */
-/* { dg-final { scan-assembler-times "cv\\.sll\\.sci\\.h" 3 } } */
+/* { dg-final { scan-assembler-times "cv\\.sll\\.sci\\.h" 2 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-sra-sc-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-sra-sc-b-compile-1.c
@@ -1,25 +1,23 @@
 /* { dg-do compile } */
 /* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
-int foo1 (int a, int b)
+int
+foo1 (int a, int b)
 {
-	return __builtin_riscv_cv_simd_sra_sc_b(a, b);
+	return __builtin_riscv_cv_simd_sra_sc_b (a, b);
 }
 
-int foo2 (int a)
+int
+foo2 (int a)
 {
-	return __builtin_riscv_cv_simd_sra_sc_b(a, -32);
+	return __builtin_riscv_cv_simd_sra_sc_b (a, 0);
 }
 
-int foo3 (int a)
+int
+foo3 (int a)
 {
-	return __builtin_riscv_cv_simd_sra_sc_b(a, 0);
-}
-
-int foo4 (int a)
-{
-	return __builtin_riscv_cv_simd_sra_sc_b(a, 31);
+	return __builtin_riscv_cv_simd_sra_sc_b (a, 63);
 }
 
 /* { dg-final { scan-assembler-times "cv\\.sra\\.sc\\.b" 1 } } */
-/* { dg-final { scan-assembler-times "cv\\.sra\\.sci\\.b" 3 } } */
+/* { dg-final { scan-assembler-times "cv\\.sra\\.sci\\.b" 2 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-sra-sc-h-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-sra-sc-h-compile-1.c
@@ -1,25 +1,23 @@
 /* { dg-do compile } */
 /* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
-int foo1 (int a, int b)
+int
+foo1 (int a, int b)
 {
-	return __builtin_riscv_cv_simd_sra_sc_h(a, b);
+	return __builtin_riscv_cv_simd_sra_sc_h (a, b);
 }
 
-int foo2 (int a)
+int
+foo2 (int a)
 {
-	return __builtin_riscv_cv_simd_sra_sc_h(a, -32);
+	return __builtin_riscv_cv_simd_sra_sc_h (a, 0);
 }
 
-int foo3 (int a)
+int
+foo3 (int a)
 {
-	return __builtin_riscv_cv_simd_sra_sc_h(a, 0);
-}
-
-int foo4 (int a)
-{
-	return __builtin_riscv_cv_simd_sra_sc_h(a, 31);
+	return __builtin_riscv_cv_simd_sra_sc_h (a, 63);
 }
 
 /* { dg-final { scan-assembler-times "cv\\.sra\\.sc\\.h" 1 } } */
-/* { dg-final { scan-assembler-times "cv\\.sra\\.sci\\.h" 3 } } */
+/* { dg-final { scan-assembler-times "cv\\.sra\\.sci\\.h" 2 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-srl-sc-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-srl-sc-b-compile-1.c
@@ -1,25 +1,23 @@
 /* { dg-do compile } */
 /* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
-int foo1 (int a, int b)
+int
+foo1 (int a, int b)
 {
-	return __builtin_riscv_cv_simd_srl_sc_b(a, b);
+	return __builtin_riscv_cv_simd_srl_sc_b (a, b);
 }
 
-int foo2 (int a)
+int
+foo2 (int a)
 {
-	return __builtin_riscv_cv_simd_srl_sc_b(a, -32);
+	return __builtin_riscv_cv_simd_srl_sc_b (a, 0);
 }
 
-int foo3 (int a)
+int
+foo3 (int a)
 {
-	return __builtin_riscv_cv_simd_srl_sc_b(a, 0);
-}
-
-int foo4 (int a)
-{
-	return __builtin_riscv_cv_simd_srl_sc_b(a, 31);
+	return __builtin_riscv_cv_simd_srl_sc_b (a, 63);
 }
 
 /* { dg-final { scan-assembler-times "cv\\.srl\\.sc\\.b" 1 } } */
-/* { dg-final { scan-assembler-times "cv\\.srl\\.sci\\.b" 3 } } */
+/* { dg-final { scan-assembler-times "cv\\.srl\\.sci\\.b" 2 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-srl-sc-h-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-srl-sc-h-compile-1.c
@@ -1,25 +1,23 @@
 /* { dg-do compile } */
 /* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
-int foo1 (int a, int b)
+int
+foo1 (int a, int b)
 {
-	return __builtin_riscv_cv_simd_srl_sc_h(a, b);
+	return __builtin_riscv_cv_simd_srl_sc_h (a, b);
 }
 
-int foo2 (int a)
+int
+foo2 (int a)
 {
-	return __builtin_riscv_cv_simd_srl_sc_h(a, -32);
+	return __builtin_riscv_cv_simd_srl_sc_h (a, 0);
 }
 
-int foo3 (int a)
+int
+foo3 (int a)
 {
-	return __builtin_riscv_cv_simd_srl_sc_h(a, 0);
-}
-
-int foo4 (int a)
-{
-	return __builtin_riscv_cv_simd_srl_sc_h(a, 31);
+	return __builtin_riscv_cv_simd_srl_sc_h (a, 63);
 }
 
 /* { dg-final { scan-assembler-times "cv\\.srl\\.sc\\.h" 1 } } */
-/* { dg-final { scan-assembler-times "cv\\.srl\\.sci\\.h" 3 } } */
+/* { dg-final { scan-assembler-times "cv\\.srl\\.sci\\.h" 2 } } */


### PR DESCRIPTION
The immediate operand order in instructions `cv.bclr` and `cv.bset` was wrong. Tests updated to match.

Tests for instructions `cv.extract[u].[h,b]` and `cv.insert.[h,b]` fixed for unsigned immediate `sel`.

Instructions `cv.s[ll,ra,la].sc.[h,b]` fixed for unsigned immediate `j`. Tests updated to match.

Files Changed:

  * config/riscv/corev.md: Various fixes.
  * gcc.target/riscv/cv-march-xcvbitmanip-compile-bclr.c: Fixed test.
  * gcc.target/riscv/cv-march-xcvbitmanip-compile-bset.c: Likewise.
  * gcc.target/riscv/cv-simd-extract-b-compile-1.c: Likewise.
  * gcc.target/riscv/cv-simd-extract-h-compile-1.c: Likewise.
  * gcc.target/riscv/cv-simd-extractu-b-compile-1.c: Likewise.
  * gcc.target/riscv/cv-simd-extractu-h-compile-1.c: Likewise.
  * gcc.target/riscv/cv-simd-insert-b-compile-1.c: Likewise.
  * gcc.target/riscv/cv-simd-insert-h-compile-1.c: Likewise.
  * gcc.target/riscv/cv-simd-sll-sc-b-compile-1.c: Likewise.
  * gcc.target/riscv/cv-simd-sll-sc-h-compile-1.c: Likewise.
  * gcc.target/riscv/cv-simd-sra-sc-b-compile-1.c: Likewise.
  * gcc.target/riscv/cv-simd-sra-sc-h-compile-1.c: Likewise.
  * gcc.target/riscv/cv-simd-srl-sc-b-compile-1.c: Likewise.
  * gcc.target/riscv/cv-simd-srl-sc-h-compile-1.c: Likewise.