### PR TITLE
Fix cv.shuffle.b.sci immediate operand

### DIFF
--- a/gcc/config/riscv/constraints.md
+++ b/gcc/config/riscv/constraints.md
@@ -139,6 +139,21 @@
   (and (match_code "const_int")
        (match_test "IN_RANGE (ival, 0, 63)")))
 
+(define_constraint "CI1"
+  "Shifting immediate for SIMD shufflei1."
+  (and (match_code "const_int")
+       (match_test "IN_RANGE (ival, 64, 127)")))
+
+(define_constraint "CI2"
+  "Shifting immediate for SIMD shufflei2."
+  (and (match_code "const_int")
+       (match_test "IN_RANGE (ival, -128, -65)")))
+
+(define_constraint "CI3"
+  "Shifting immediate for SIMD shufflei3."
+  (and (match_code "const_int")
+       (match_test "IN_RANGE (ival, -64, -1)")))
+
 (define_constraint "CF0"
   "Shifting immediate for SIMD complex number, div operations, add and sub."
   (and (match_code "const_int")

--- a/gcc/config/riscv/corev.md
+++ b/gcc/config/riscv/corev.md
@@ -1927,14 +1927,14 @@
 (define_insn "riscv_cv_simd_shuffle_sci_b_si"
 	[(set (match_operand:SI 0 "register_operand" "=r,r,r,r")
 		(unspec:SI [(match_operand:SI 1 "register_operand" "r,r,r,r")
-		(match_operand:QI 2 "const_int2_operand" "CF0,CF1,CF2,CF3")]
+		(match_operand:QI 2 "const_int_operand" "CS6,CI1,CI2,CI3")]
 	UNSPEC_CV_SHUFFLE_SCI_B))]
 	"TARGET_XCVSIMD && !TARGET_64BIT"
 	"@
-   cv.shufflei0.sci.b\\t%0,%1,%2
-   cv.shufflei1.sci.b\\t%0,%1,%2
-   cv.shufflei2.sci.b\\t%0,%1,%2
-   cv.shufflei3.sci.b\\t%0,%1,%2"
+   cv.shufflei0.sci.b\\t%0,%1,%x2
+   cv.shufflei1.sci.b\\t%0,%1,%x2
+   cv.shufflei2.sci.b\\t%0,%1,%x2
+   cv.shufflei3.sci.b\\t%0,%1,%x2"
 	[(set_attr "type" "arith")
 	(set_attr "mode" "SI")])
 

--- a/gcc/config/riscv/riscv.cc
+++ b/gcc/config/riscv/riscv.cc
@@ -4404,6 +4404,8 @@ riscv_memmodel_needs_release_fence (enum memmodel model)
    'T'	Print shift-index of inverted single-bit mask OP.
    '~'	Print w if TARGET_64BIT is true; otherwise not print anything.
 
+   'x'  Print immediate for CORE-V.
+
    Note please keep this list and the list in riscv.md in sync.  */
 
 static void
@@ -4592,6 +4594,14 @@ riscv_print_operand (FILE *file, rtx op, int letter)
     case 'T':
       {
 	rtx newop = GEN_INT (ctz_hwi (~INTVAL (op)));
+	output_addr_const (file, newop);
+	break;
+      }
+    case 'x':
+      {
+	unsigned int imm = (UINTVAL (op) & 63);
+	gcc_assert (imm <= 63);
+	rtx newop = GEN_INT (imm);
 	output_addr_const (file, newop);
 	break;
       }

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-shufflei0-sci-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-shufflei0-sci-b-compile-1.c
@@ -1,9 +1,18 @@
 /* { dg-do compile } */
 /* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
-int foo1 (int a)
+int
+foo1 (int a)
 {
-	return __builtin_riscv_cv_simd_shuffle_sci_b(a, 0);
+	return __builtin_riscv_cv_simd_shuffle_sci_b (a, 0);
 }
 
-/* { dg-final { scan-assembler-times "cv\\.shufflei0\\.sci\\.b" 1 } } */
+int
+foo2 (int a)
+{
+        return __builtin_riscv_cv_simd_shuffle_sci_b (a, 63);
+}
+
+/* { dg-final { scan-assembler-times "cv\\.shufflei0\\.sci\\.b" 2 } } */
+/* { dg-final { scan-assembler-times "cv\\.shufflei0\\.sci\\.b\t\[a-z\]\[0-99\],\[a-z\]\[0-99\],0" 1 } } */
+/* { dg-final { scan-assembler-times "cv\\.shufflei0\\.sci\\.b\t\[a-z\]\[0-99\],\[a-z\]\[0-99\],63" 1 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-shufflei1-sci-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-shufflei1-sci-b-compile-1.c
@@ -1,9 +1,18 @@
 /* { dg-do compile } */
 /* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
-int foo1 (int a)
+int
+foo1 (int a)
 {
-	return __builtin_riscv_cv_simd_shuffle_sci_b(a, 1);
+	return __builtin_riscv_cv_simd_shuffle_sci_b (a, 64);
 }
 
-/* { dg-final { scan-assembler-times "cv\\.shufflei1\\.sci\\.b" 1 } } */
+int
+foo2 (int a)
+{
+        return __builtin_riscv_cv_simd_shuffle_sci_b (a, 127);
+}
+
+/* { dg-final { scan-assembler-times "cv\\.shufflei1\\.sci\\.b" 2 } } */
+/* { dg-final { scan-assembler-times "cv\\.shufflei1\\.sci\\.b\t\[a-z\]\[0-99\],\[a-z\]\[0-99\],0" 1 } } */
+/* { dg-final { scan-assembler-times "cv\\.shufflei1\\.sci\\.b\t\[a-z\]\[0-99\],\[a-z\]\[0-99\],63" 1 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-shufflei2-sci-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-shufflei2-sci-b-compile-1.c
@@ -1,9 +1,18 @@
 /* { dg-do compile } */
 /* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
-int foo1 (int a)
+unsigned int
+foo1 (unsigned int a)
 {
-	return __builtin_riscv_cv_simd_shuffle_sci_b(a, 2);
+	return __builtin_riscv_cv_simd_shuffle_sci_b (a, 128);
 }
 
-/* { dg-final { scan-assembler-times "cv\\.shufflei2\\.sci\\.b" 1 } } */
+unsigned int
+foo2 (unsigned int a)
+{
+        return __builtin_riscv_cv_simd_shuffle_sci_b (a, 191);
+}
+
+/* { dg-final { scan-assembler-times "cv\\.shufflei2\\.sci\\.b" 2 } } */
+/* { dg-final { scan-assembler-times "cv\\.shufflei2\\.sci\\.b\t\[a-z\]\[0-99\],\[a-z\]\[0-99\],0" 1 } } */
+/* { dg-final { scan-assembler-times "cv\\.shufflei2\\.sci\\.b\t\[a-z\]\[0-99\],\[a-z\]\[0-99\],63" 1 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-simd-shufflei3-sci-b-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-simd-shufflei3-sci-b-compile-1.c
@@ -1,9 +1,18 @@
 /* { dg-do compile } */
 /* { dg-options "-march=rv32i_xcvsimd -mabi=ilp32" } */
 
-int foo1 (int a)
+int
+foo1 (int a)
 {
-	return __builtin_riscv_cv_simd_shuffle_sci_b(a, 3);
+	return __builtin_riscv_cv_simd_shuffle_sci_b (a, 192);
 }
 
-/* { dg-final { scan-assembler-times "cv\\.shufflei3\\.sci\\.b" 1 } } */
+int
+foo2 (int a)
+{
+        return __builtin_riscv_cv_simd_shuffle_sci_b (a, 255);
+}
+
+/* { dg-final { scan-assembler-times "cv\\.shufflei3\\.sci\\.b" 2 } } */
+/* { dg-final { scan-assembler-times "cv\\.shufflei3\\.sci\\.b\t\[a-z\]\[0-99\],\[a-z\]\[0-99\],0" 1 } } */
+/* { dg-final { scan-assembler-times "cv\\.shufflei3\\.sci\\.b\t\[a-z\]\[0-99\],\[a-z\]\[0-99\],63" 1 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-xcvsimd-march-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-xcvsimd-march-compile-1.c
@@ -796,19 +796,19 @@ int foo132 (int a)
 
 int foo133 (int a)
 {
-	return __builtin_riscv_cv_simd_shuffle_sci_b(a, 1);
+	return __builtin_riscv_cv_simd_shuffle_sci_b(a, 64);
 }
 
 
 int foo134 (int a)
 {
-	return __builtin_riscv_cv_simd_shuffle_sci_b(a, 2);
+	return __builtin_riscv_cv_simd_shuffle_sci_b(a, 128);
 }
 
 
 int foo135 (int a)
 {
-	return __builtin_riscv_cv_simd_shuffle_sci_b(a, 3);
+	return __builtin_riscv_cv_simd_shuffle_sci_b(a, 192);
 }
 
 


### PR DESCRIPTION
Issue [#68](https://github.com/openhwgroup/corev-gcc/issues/68)

The built-in for `cv.shuffle.b.sci` takes an 8-bit immediate operand. The top two bits decides which `cv.shufflei*` instruction is used. The other six bits are printed.

Files Changed:

  * config/riscv/constraints.md: Added new constraints to check the top two bits.
  * config/riscv/corev.md: Likewise.
  * config/riscv/riscv.cc: Added new operand type for printing the bottom six bits.
  * testsuite/gcc.target/riscv/cv-simd-shufflei0-sci-b-compile-1.c: Updated test.
  * testsuite/gcc.target/riscv/cv-simd-shufflei1-sci-b-compile-1.c: Likewise.
  * testsuite/gcc.target/riscv/cv-simd-shufflei2-sci-b-compile-1.c: Likewise.
  * testsuite/gcc.target/riscv/cv-simd-shufflei3-sci-b-compile-1.c: Likewise.
  * testsuite/gcc.target/riscv/cv-xcvsimd-march-compile-1.c: Likewise.