### PR TITLE
Fix mem_plus_reg predicate

### DIFF
--- a/gcc/config/riscv/constraints.md
+++ b/gcc/config/riscv/constraints.md
@@ -128,6 +128,11 @@
   (and (match_code "mem")
        (match_test "GET_CODE(XEXP(op,0)) == REG")))
 
+(define_memory_constraint "am"
+  "An address that is held in a general-purpose register."
+  (and (match_code "mem")
+       (match_test "!(GET_CODE(XEXP(op,0)) == PLUS && GET_CODE(XEXP(XEXP(op,0),0)) == REG && GET_CODE(XEXP(XEXP(op,0),1)) == REG)")))
+
 (define_constraint "S"
   "A constraint that matches an absolute symbolic address."
   (match_operand 0 "absolute_symbolic_operand"))

--- a/gcc/config/riscv/predicates.md
+++ b/gcc/config/riscv/predicates.md
@@ -240,8 +240,9 @@
 
 (define_predicate "mem_plus_reg"
   (and (match_code "mem")
-       (match_test "TARGET_XCVMEM && GET_CODE (XEXP (op, 0)) == PLUS
-		    && REG_P (XEXP (XEXP (op, 0), 1))")))
+       (match_test "GET_CODE (XEXP (op, 0)) == PLUS
+		    && REG_P (XEXP (XEXP (op, 0), 1))
+		    && REG_P (XEXP (XEXP (op, 0), 0))")))
 
 (define_predicate "move_operand"
   (and (match_operand 0 "general_operand")
@@ -449,9 +450,7 @@
 
 (define_predicate "nonimmediate_nonpostinc"
   (and (match_operand 0 "nonimmediate_operand")
-	(and (not (match_operand 0 "mem_post_inc"))
-	     (not (match_operand 0 "mem_plus_reg")))))
-
+	(not (match_operand 0 "mem_post_inc"))))
 
 ;; Predicates for the V extension.
 (define_special_predicate "vector_length_operand"

--- a/gcc/config/riscv/riscv.cc
+++ b/gcc/config/riscv/riscv.cc
@@ -2494,7 +2494,7 @@ riscv_legitimate_xcvmem_address_p (machine_mode mode, rtx x, bool strict_p)
       return false;
 
     case PLUS:
-      if (REG_P (XEXP (x, 1)) && riscv_classify_address (&addr, x, mode, strict_p))
+      if (REG_P (XEXP (x, 0)) && REG_P (XEXP (x, 1)) && riscv_classify_address (&addr, x, mode, strict_p))
         return addr.type == ADDRESS_REG;
       return false;
 

--- a/gcc/config/riscv/riscv.md
+++ b/gcc/config/riscv/riscv.md
@@ -2166,7 +2166,7 @@
 
 (define_insn "*movsf_hardfloat"
   [(set (match_operand:SF 0 "nonimmediate_nonpostinc" "=f,   f,f,f,m,m,*f,*r,  *r,*r,*m")
-	(match_operand:SF 1 "move_operand"         " f,zfli,G,m,f,G,*r,*f,*G*r,*m,*r"))]
+	(match_operand:SF 1 "move_operand"         " f,zfli,G,am,f,G,*r,*f,*G*r,*m,*r"))]
   "TARGET_HARD_FLOAT
    && (register_operand (operands[0], SFmode)
        || reg_or_0_operand (operands[1], SFmode))"

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-flw-fail.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-flw-fail.c
@@ -1,0 +1,17 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv32if_xcvmem" } */
+
+// Error: illegal operands `flw fa5,a5(a4)'
+
+int b, e;
+float *m;
+
+int
+foo (void) {
+  m[1] = m[b];
+  m[b] = e;
+
+  return 0;
+}
+
+/* { dg-final { scan-assembler-not "flw\tfa5,a5\\(a4\\)" } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-sw-fail-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-sw-fail-1.c
@@ -1,0 +1,23 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv32i_xcvmem -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* }  { "-O0 -O3" } { "" } } */
+
+/* Tests that sw can generate reg:imm stores */
+
+int a[1];
+int b, c, d, e, f;
+float g;
+
+int
+foo (void)
+{
+  int h;
+  for (;; d++)
+    switch (c) {
+    case 8:
+      g = e == f;
+      a[h + d] = g;
+      g = e < f;
+      b = g;
+    }
+}


### PR DESCRIPTION
Issues #73 #74 

mem_plus_reg needs to check that both operands are registers.
Added constraint to prevent operands `(mem (plus reg reg))`.