### PR TITLE
Exclude CORE-V memory tests for compressed code generation.

### DIFF
--- a/gcc/testsuite/gcc.target/riscv/cv-mem-lb-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-lb-compile-1.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-options "-march=rv32i_xcvmem -mabi=ilp32 -fno-unroll-loops" } */
-/* { dg-skip-if "" { *-*-* }  { "-O0" } { "" } } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-Os" "-Oz" "-Og" } } */
 
 int fooQIsigned (signed char* array_char, int n)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-lb-compile-2.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-lb-compile-2.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-options "-march=rv32i_xcvmem -mabi=ilp32 -fno-unroll-loops" } */
-/* { dg-skip-if "" { *-*-* }  { "-O0" } { "" } } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-Os" "-Oz" "-Og" } } */
 
 int fooQIsigned (signed char* array_char, int n, int j)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-lbu-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-lbu-compile-1.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-options "-march=rv32i_xcvmem -mabi=ilp32 -fno-unroll-loops" } */
-/* { dg-skip-if "" { *-*-* }  { "-O0" } { "" } } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-Os" "-Oz" "-Og" } } */
 
 int fooQIunsigned (unsigned char* array_uchar, int n)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-lbu-compile-2.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-lbu-compile-2.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-options "-march=rv32i_xcvmem -mabi=ilp32 -fno-unroll-loops" } */
-/* { dg-skip-if "" { *-*-* }  { "-O0" } { "" } } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-Os" "-Oz" "-Og" } } */
 
 int fooQIunsigned (unsigned char* array_uchar, int n, int j)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-lh-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-lh-compile-1.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-options "-march=rv32i_xcvmem -mabi=ilp32 -fno-unroll-loops" } */
-/* { dg-skip-if "" { *-*-* }  { "-O0" } { "" } } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-Os" "-Oz" "-Og" } } */
 
 int fooHIsigned (signed short int* array_short, int n)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-lh-compile-2.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-lh-compile-2.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-options "-march=rv32i_xcvmem -mabi=ilp32 -fno-unroll-loops" } */
-/* { dg-skip-if "" { *-*-* }  { "-O0" } { "" } } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-Os" "-Oz" "-Og" } } */
 
 int fooHIsigned (signed short int* array_short, int n, int j)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-lhu-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-lhu-compile-1.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-options "-march=rv32i_xcvmem -mabi=ilp32 -fno-unroll-loops" } */
-/* { dg-skip-if "" { *-*-* }  { "-O0" } { "" } } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-Os" "-Oz" "-Og" } } */
 
 int fooHIunsigned (unsigned short int* array_ushort, int n)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-lhu-compile-2.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-lhu-compile-2.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-options "-march=rv32i_xcvmem -mabi=ilp32 -fno-unroll-loops" } */
-/* { dg-skip-if "" { *-*-* }  { "-O0" } { "" } } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-Os" "-Oz" "-Og" } } */
 
 int fooHIunsigned (unsigned short int* array_ushort, int n, int j)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-lw-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-lw-compile-1.c
@@ -1,6 +1,8 @@
 /* { dg-do compile } */
 /* { dg-options "-march=rv32i_xcvmem -mabi=ilp32 -fno-unroll-loops" } */
-/* { dg-skip-if "" { *-*-* }  { "-O0" } { "" } } */
+/* We don't generate for some optimization levels. TODO: should support for Os,
+   Oz and Og */
+/* { dg-skip-if "" { *-*-* }  { "-O0" "-Os" "-Oz" "-Og" } { "" } } */
 
 /*
  * Test for post-inc register-immediate loads.

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-lw-compile-2.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-lw-compile-2.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-options "-march=rv32i_xcvmem -mabi=ilp32 -fno-unroll-loops" } */
-/* { dg-skip-if "" { *-*-* }  { "-O0" } { "" } } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-Os" "-Oz" "-Og" } } */
 
 /*
  * Test for post-inc register-register loads.

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-sb-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-sb-compile-1.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-options "-march=rv32i_xcvmem -mabi=ilp32 -fno-unroll-loops -fno-tree-vectorize" } */
-/* { dg-skip-if "" { *-*-* }  { "-O0" } { "" } } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-Os" "-Oz" "-Og" } } */
 
 int fooQIsigned (signed char* array_char, int n)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-sb-compile-2.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-sb-compile-2.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-options "-march=rv32i_xcvmem -mabi=ilp32 -fno-unroll-loops -fno-tree-vectorize" } */
-/* { dg-skip-if "" { *-*-* }  { "-O0" } { "" } } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-Os" "-Oz" "-Og" } } */
 
 int fooQIsigned (signed char* array_char, int n, int j)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-sh-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-sh-compile-1.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-options "-march=rv32i_xcvmem -mabi=ilp32 -fno-unroll-loops" } */
-/* { dg-skip-if "" { *-*-* }  { "-O0" } { "" } } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-Os" "-Oz" "-Og" } } */
 
 int fooHIsigned (signed short int* array_short, int n)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-sh-compile-2.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-sh-compile-2.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-options "-march=rv32i_xcvmem -mabi=ilp32 -fno-unroll-loops" } */
-/* { dg-skip-if "" { *-*-* }  { "-O0" } { "" } } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-Os" "-Oz" "-Og" } } */
 
 int fooHIsigned (signed short int* array_short, int n, int j)
 {

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-sw-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-sw-compile-1.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-options "-march=rv32i_xcvmem -mabi=ilp32 -fno-unroll-loops" } */
-/* { dg-skip-if "" { *-*-* }  { "-O0" } { "" } } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-Os" "-Oz" "-Og" } } */
 
 /*
  * Test for post-inc register-immediate saves.

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-sw-compile-2.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-sw-compile-2.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-options "-march=rv32i_xcvmem -mabi=ilp32 -fno-unroll-loops" } */
-/* { dg-skip-if "" { *-*-* }  { "-O0" } { "" } } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-Os" "-Oz" "-Og" } } */
 
 /*
  * Test for post-inc register-register saves.


### PR DESCRIPTION
	The generation of CORE-V memory instructions in these tests only
	occurs for performance optimization levels (01, 02, 03), but not
	for unoptimized code (00, 0g) or for compressed optimization (0s,
	Oz).

gcc/testsuite/

	* gcc.target/riscv/cv-mem-lb-compile-1.c: Exclude running at -O0, -Os, -Og as well as -O0.
	* gcc.target/riscv/cv-mem-lb-compile-2.c: Likewise.
	* gcc.target/riscv/cv-mem-lbu-compile-1.c: Likewise.
	* gcc.target/riscv/cv-mem-lbu-compile-2.c: Likewise.
	* gcc.target/riscv/cv-mem-lh-compile-1.c: Likewise.
	* gcc.target/riscv/cv-mem-lh-compile-2.c: Likewise.
	* gcc.target/riscv/cv-mem-lhu-compile-1.c: Likewise.
	* gcc.target/riscv/cv-mem-lhu-compile-2.c: Likewise.
	* gcc.target/riscv/cv-mem-lw-compile-1.c: Likewise.
	* gcc.target/riscv/cv-mem-lw-compile-2.c: Likewise.
	* gcc.target/riscv/cv-mem-sb-compile-1.c: Likewise.
	* gcc.target/riscv/cv-mem-sb-compile-2.c: Likewise.
	* gcc.target/riscv/cv-mem-sh-compile-1.c: Likewise.
	* gcc.target/riscv/cv-mem-sh-compile-2.c: Likewise.
	* gcc.target/riscv/cv-mem-sw-compile-1.c: Likewise.
	* gcc.target/riscv/cv-mem-sw-compile-2.c: Likewise.