### PR TITLE
Tests added for XCVhwlp

### DIFF
--- a/gcc/testsuite/gcc.target/riscv/cv-hwlp-split-fail.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-hwlp-split-fail.c
@@ -1,0 +1,13 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv32imc_xcvhwlp -mabi=ilp32 -O2" } */
+
+char *a;
+int b, c;
+
+int
+foo ()
+{
+  char e = 0;
+  for (; e < 6; e++)
+    a[b] |= a[e] |= a[b] |= a[c + e >> 4 * b] |= 80 >> e + 1;
+}

--- a/gcc/testsuite/gcc.target/riscv/cv-hwlp-ui12-fail.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-hwlp-ui12-fail.c
@@ -1,0 +1,35 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv32imc_xcvhwlp -mabi=ilp32 -O2" } */
+
+int *c;
+int d[12];
+int e;
+int b ();
+
+int
+bar ()
+{
+  volatile int a = b ();
+}
+
+int
+foo ()
+{
+  short g, h;
+  for (; e;)
+    {
+      g = 0;
+      for (; g < 8; g++)
+	{
+	  h = 0;
+	  for (; h < 4; h++)
+	    d[h] = c[h] = d[0];
+	}
+    }
+}
+
+int
+b ()
+{
+  return foo();
+}


### PR DESCRIPTION
Fix for issue [#89](https://github.com/openhwgroup/corev-gcc/issues/89)

Files Changed:

  * gcc/testsuite/gcc.target/riscv/cv-hwlp-split-fail.c: New test.
  * gcc/testsuite/gcc.target/riscv/cv-hwlp-ui12-fail.c: New test.

