### PR TITLE
Change the priority of the XCVmem instructions

### DIFF
--- a/gcc/config/riscv/riscv.md
+++ b/gcc/config/riscv/riscv.md
@@ -601,10 +601,6 @@
   (eq_attr "type" "ghost")
   "nothing")
 
-;; TODO: for xcvmem to generate post-inc instructions, corev.md must
-;; appear before the mov instructions. This should be fixed.
-(include "corev.md")
-
 ;;
 ;;  ....................
 ;;
@@ -1710,7 +1706,7 @@
   [(set (match_operand:GPR    0 "register_operand"     "=r,r")
 	(zero_extend:GPR
 	    (match_operand:HI 1 "nonimmediate_nonpostinc" " r,m")))]
-  "!TARGET_ZBB && !TARGET_XTHEADBB && !TARGET_XTHEADMEMIDX"
+  "!TARGET_ZBB && !TARGET_XTHEADBB && !TARGET_XTHEADMEMIDX && !TARGET_XCVMEM"
   "@
    #
    lhu\t%0,%1"
@@ -1739,7 +1735,7 @@
   [(set (match_operand:SUPERQI 0 "register_operand"    "=r,r")
 	(zero_extend:SUPERQI
 	    (match_operand:QI 1 "nonimmediate_nonpostinc" " r,m")))]
-  "!TARGET_XTHEADMEMIDX"
+  "!TARGET_XTHEADMEMIDX && !TARGET_XCVMEM"
   "@
    andi\t%0,%1,0xff
    lbu\t%0,%1"
@@ -1781,7 +1777,7 @@
   [(set (match_operand:SUPERQI   0 "register_operand"     "=r,r")
 	(sign_extend:SUPERQI
 	    (match_operand:SHORT 1 "nonimmediate_nonpostinc" " r,m")))]
-  "!TARGET_ZBB && !TARGET_XTHEADBB && !TARGET_XTHEADMEMIDX"
+  "!TARGET_ZBB && !TARGET_XTHEADBB && !TARGET_XTHEADMEMIDX && !TARGET_XCVMEM"
   "@
    #
    l<SHORT:size>\t%0,%1"
@@ -1841,7 +1837,7 @@
 (define_insn "*movhf_hardfloat"
   [(set (match_operand:HF 0 "nonimmediate_nonpostinc" "=f,   f,f,f,m,m,*f,*r,  *r,*r,*m")
 	(match_operand:HF 1 "move_operand"         " f,zfli,G,m,f,G,*r,*f,*G*r,*m,*r"))]
-  "TARGET_ZFHMIN
+  "TARGET_ZFHMIN && !TARGET_XCVMEM
    && (register_operand (operands[0], HFmode)
        || reg_or_0_operand (operands[1], HFmode))"
   { return riscv_output_move (operands[0], operands[1]); }
@@ -1852,7 +1848,7 @@
 (define_insn "*movhf_softfloat"
   [(set (match_operand:HF 0 "nonimmediate_nonpostinc" "=f, r,r,m,*f,*r")
 	(match_operand:HF 1 "move_operand"         " f,Gr,m,r,*r,*f"))]
-  "!TARGET_ZFHMIN
+  "!TARGET_ZFHMIN && !TARGET_XCVMEM
    && (register_operand (operands[0], HFmode)
        || reg_or_0_operand (operands[1], HFmode))"
   { return riscv_output_move (operands[0], operands[1]); }
@@ -2111,7 +2107,7 @@
 (define_insn "*movsi_internal"
   [(set (match_operand:SI 0 "move_dest_operand" "=r,r,r, m,  *f,*f,*r,*m,r,r,r")
 	(match_operand:SI 1 "move_operand"      " r,T,m,rJ,*r*J,*m,*f,*f,vp,xcvl0c,xcvl1c"))]
-  "(register_operand (operands[0], SImode)
+  "!TARGET_XCVMEM && (register_operand (operands[0], SImode)
     || reg_or_0_operand (operands[1], SImode))
     && !(register_operand (operands[1], SImode)
          && reg_or_subregno (operands[1]) == VL_REGNUM)"
@@ -2140,7 +2136,7 @@
 (define_insn "*movhi_internal"
   [(set (match_operand:HI 0 "nonimmediate_nonpostinc" "=r,r,r, m,  *f,*r,r")
 	(match_operand:HI 1 "move_operand"	   " r,T,m,rJ,*r*J,*f,vp"))]
-  "(register_operand (operands[0], HImode)
+  "!TARGET_XCVMEM && (register_operand (operands[0], HImode)
     || reg_or_0_operand (operands[1], HImode))"
   { return riscv_output_move (operands[0], operands[1]); }
   [(set_attr "move_type" "move,const,load,store,mtc,mfc,rdvlenb")
@@ -2184,7 +2180,7 @@
 (define_insn "*movqi_internal"
   [(set (match_operand:QI 0 "nonimmediate_nonpostinc" "=r,r,r, m,  *f,*r,r")
 	(match_operand:QI 1 "move_operand"         " r,I,m,rJ,*r*J,*f,vp"))]
-  "(register_operand (operands[0], QImode)
+  "!TARGET_XCVMEM && (register_operand (operands[0], QImode)
     || reg_or_0_operand (operands[1], QImode))"
   { return riscv_output_move (operands[0], operands[1]); }
   [(set_attr "move_type" "move,const,load,store,mtc,mfc,rdvlenb")
@@ -3656,3 +3652,4 @@
 (include "vector.md")
 (include "zicond.md")
 (include "zc.md")
+(include "corev.md")


### PR DESCRIPTION
Returned corev.md to be included at the bottom of riscv.md.

Issue #88 fix

Files Changed:
 * corev.md: Added generic load/ store instructions with lower priority than the XCVmem load/ store instructions.
 * riscv.md: Prevent generic load/ store instructions having higher priority than XCVmem load/ store if the extension is included.
