### PR TITLE
Add header file for XCValu

### DIFF
--- a/gcc/config.gcc
+++ b/gcc/config.gcc
@@ -549,7 +549,7 @@ riscv*)
 	extra_objs="${extra_objs} riscv-vector-builtins.o riscv-vector-builtins-shapes.o riscv-vector-builtins-bases.o"
 	extra_objs="${extra_objs} thead.o riscv-target-attr.o corev.o"
 	d_target_objs="riscv-d.o"
-	extra_headers="riscv_vector.h"
+	extra_headers="riscv_vector.h riscv_corev_alu.h"
 	target_gtfiles="$target_gtfiles \$(srcdir)/config/riscv/riscv-vector-builtins.cc"
 	target_gtfiles="$target_gtfiles \$(srcdir)/config/riscv/riscv-vector-builtins.h"
 	;;

--- a/gcc/config/riscv/riscv_corev_alu.h
+++ b/gcc/config/riscv/riscv_corev_alu.h
@@ -1,0 +1,66 @@
+/* riscv_corev_alu.h - CORE-V ALU intrinsics
+   Copyright (C) 2022-2023 Free Software Foundation, Inc.
+
+   This file is part of GCC.
+
+   GCC is free software; you can redistribute it and/or modify it
+   under the terms of the GNU General Public License as published
+   by the Free Software Foundation; either version 3, or (at your
+   option) any later version.
+
+   GCC is distributed in the hope that it will be useful, but WITHOUT
+   ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+   or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+   License for more details.
+
+   Under Section 7 of GPL version 3, you are granted additional
+   permissions described in the GCC Runtime Library Exception, version
+   3.1, as published by the Free Software Foundation.
+
+   You should have received a copy of the GNU General Public License and
+   a copy of the GCC Runtime Library Exception along with this program;
+   see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+   <http://www.gnu.org/licenses/>.  */
+
+#ifndef __RISCV_COREV_ALU_H
+#define __RISCV_COREV_ALU_H
+
+#include <stdint.h>
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+#if defined(__riscv_xcvalu)
+
+#define __DEFAULT_FN_ATTRS __attribute__((__always_inline__, __nodebug__))
+
+#define __riscv_cv_abs(a) __builtin_abs(a)
+#define __riscv_cv_alu_slet(a,b) __builtin_riscv_cv_alu_slet(a,b)
+#define __riscv_cv_alu_sletu(a,b) __builtin_riscv_cv_alu_sletu(a,b)
+#define __riscv_cv_alu_min(a,b) __builtin_riscv_cv_alu_min(a,b)
+#define __riscv_cv_alu_minu(a,b) __builtin_riscv_cv_alu_minu(a,b)
+#define __riscv_cv_alu_max(a,b) __builtin_riscv_cv_alu_max(a,b)
+#define __riscv_cv_alu_maxu(a,b) __builtin_riscv_cv_alu_maxu(a,b)
+#define __riscv_cv_alu_exths(a) __builtin_riscv_cv_alu_exths(a)
+#define __riscv_cv_alu_exthz(a) __builtin_riscv_cv_alu_exthz(a)
+#define __riscv_cv_alu_extbs(a) __builtin_riscv_cv_alu_extbs(a)
+#define __riscv_cv_alu_extbz(a) __builtin_riscv_cv_alu_extbz(a)
+#define __riscv_cv_alu_clip(a,b) __builtin_riscv_cv_alu_clip(a,b)
+#define __riscv_cv_alu_clipu(a,b) __builtin_riscv_cv_alu_clipu(a,b)
+#define __riscv_cv_alu_addN(a,b,shft) __builtin_riscv_cv_alu_addN(a,b,shft)
+#define __riscv_cv_alu_adduN(a,b,shft) __builtin_riscv_cv_alu_adduN(a,b,shft)
+#define __riscv_cv_alu_addRN(a,b,shft) __builtin_riscv_cv_alu_addRN(a,b,shft)
+#define __riscv_cv_alu_adduRN(a,b,shft) __builtin_riscv_cv_alu_adduRN(a,b,shft)
+#define __riscv_cv_alu_subN(a,b,shft) __builtin_riscv_cv_alu_subN(a,b,shft)
+#define __riscv_cv_alu_subuN(a,b,shft) __builtin_riscv_cv_alu_subuN(a,b,shft)
+#define __riscv_cv_alu_subRN(a,b,shft) __builtin_riscv_cv_alu_subRN(a,b,shft)
+#define __riscv_cv_alu_subuRN(a,b,shft) __builtin_riscv_cv_alu_subuRN(a,b,shft)
+
+#endif // defined(__riscv_xcvalu)
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif // define __RISCV_COREV_ALU_H

--- a/gcc/testsuite/gcc.target/riscv/alu-c-api.c
+++ b/gcc/testsuite/gcc.target/riscv/alu-c-api.c
@@ -1,0 +1,107 @@
+/* { dg-do compile } */
+/* { dg-require-effective-target cv_alu } */
+/* { dg-options "-march=rv32i_xcvalu -mabi=ilp32" } */
+
+#include <stdint.h>
+#include <riscv_corev_alu.h>
+
+int
+test_alu_slet (int32_t a, int32_t b)
+{
+  return __riscv_cv_alu_slet(a, b);
+}
+
+int
+test_alu_sletu (uint32_t a, uint32_t b) {
+  return __riscv_cv_alu_sletu(a, b);
+}
+
+int
+test_alu_min (int32_t a, int32_t b) {
+  return __riscv_cv_alu_min(a, b);
+}
+
+int
+test_alu_minu (uint32_t a, uint32_t b) {
+  return __riscv_cv_alu_minu(a, b);
+}
+
+int
+test_alu_max (int32_t a, int32_t b) {
+  return __riscv_cv_alu_max(a, b);
+}
+
+int
+test_alu_maxu (uint32_t a, uint32_t b) {
+  return __riscv_cv_alu_maxu(a, b);
+}
+
+int
+test_alu_exths (int16_t a) {
+  return __riscv_cv_alu_exths(a);
+}
+
+int
+test_alu_exthz (uint16_t a) {
+  return __riscv_cv_alu_exthz(a);
+}
+
+int
+test_alu_extbs (int8_t a) {
+  return __riscv_cv_alu_extbs(a);
+}
+
+int
+test_alu_extbz (uint8_t a) {
+  return __riscv_cv_alu_extbz(a);
+}
+
+int
+test_alu_clip (int32_t a) {
+  return __riscv_cv_alu_clip(a, 0);
+}
+
+int
+test_alu_clipu (uint32_t a) {
+  return __riscv_cv_alu_clipu(a, 0);
+}
+
+int
+test_alu_addN (int32_t a, int32_t b) {
+  return __riscv_cv_alu_addN(a, b, 0);
+}
+
+int
+test_alu_adduN (uint32_t a, uint32_t b) {
+  return __riscv_cv_alu_adduN(a, b, 0);
+}
+
+int
+test_alu_addRN (int32_t a, int32_t b) {
+  return __riscv_cv_alu_addRN(a, b, 0);
+}
+
+int
+test_alu_adduRN (uint32_t a, uint32_t b) {
+  return __riscv_cv_alu_adduRN(a, b, 0);
+}
+
+int
+test_alu_subN (int32_t a, int32_t b) {
+  return __riscv_cv_alu_subN(a, b, 0);
+}
+
+int
+test_alu_subuN (uint32_t a, uint32_t b) {
+  return __riscv_cv_alu_subuN(a, b, 0);
+}
+
+int
+test_alu_subRN (int32_t a, int32_t b) {
+  return __riscv_cv_alu_subRN(a, b, 0);
+}
+
+int
+test_alu_subuRN (uint32_t a, uint32_t b) {
+  return __riscv_cv_alu_subuRN(a, b, 0);
+}


### PR DESCRIPTION
Files Changed:
  * gcc/config.gcc: Add header file.
  * gcc/config/riscv/riscv_corev_alu.h: Add header file.
  * gcc/testsuite/gcc.target/riscv/alu-c-api.c: New Test.

AP:

- [x] Add test case for headers
- [x] Locally test that headers work with find/ replace
