### PR TITLE
Change xcvmem tests to run for Os and Oz

### DIFF
--- a/gcc/testsuite/gcc.target/riscv/cv-mem-lb-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-lb-compile-1.c
@@ -12,10 +12,8 @@ fooQIsigned (signed char* array_char, int n)
 {
   int char_sum = 1;
 
-  for(int i=0; i<n; i++)
-  {
-    char_sum += array_char[i];
-  }
+  for (int i = 0; i < n; i++)
+    char_sum += array_char [i];
 
   return char_sum;
 }

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-lb-compile-2.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-lb-compile-2.c
@@ -1,21 +1,21 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_mem } */
 /* { dg-options "-march=rv32i_xcvmem -mabi=ilp32 -fno-unroll-loops" } */
-/* { dg-skip-if "" { *-*-* } { "-O0" "-Os" "-Oz" "-Og" } } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-Og" } } */
 
 /*
  * Test for post-inc register-register loads.
  */
 
 int
-fooQIsigned (signed char* array_char, int n, int j)
+fooQIsigned (signed char* array_char, int j)
 {
   int char_sum = 1;
 
-  for(int i=0; i<n; i+=j)
+  for (int i = 0; i < 5; i += j)
   {
     char_sum += *array_char;
-    array_char+=j*sizeof(array_char);
+    array_char += j * sizeof (array_char);
   }
 
   return char_sum;

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-lb-compile-3.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-lb-compile-3.c
@@ -10,7 +10,7 @@
 int
 fooQIsigned (signed char* array_char, int i, int j)
 {
-  return array_char[i+j];
+  return array_char [i + j];
 }
 
 /* { dg-final { scan-assembler-times "cv\\.lb\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\(\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\)" 1 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-lbu-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-lbu-compile-1.c
@@ -12,10 +12,8 @@ fooQIunsigned (unsigned char* array_uchar, int n)
 {
   int uns_char_sum = 1;
 
-  for(int i=0; i<n; i++)
-  {
-    uns_char_sum += array_uchar[i];
-  }
+  for (int i = 0; i < n; i++)
+    uns_char_sum += array_uchar [i];
 
   return uns_char_sum;
 }

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-lbu-compile-2.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-lbu-compile-2.c
@@ -1,21 +1,21 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_mem } */
 /* { dg-options "-march=rv32i_xcvmem -mabi=ilp32 -fno-unroll-loops" } */
-/* { dg-skip-if "" { *-*-* } { "-O0" "-Os" "-Oz" "-Og" } } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-Og" } } */
 
 /*
  * Test for post-inc register-register loads.
  */
 
 int
-fooQIunsigned (unsigned char* array_uchar, int n, int j)
+fooQIunsigned (unsigned char* array_uchar, int j)
 {
   int uns_char_sum = 1;
 
-  for(int i=0; i<n; i+=j)
+  for (int i = 0; i < 5; i += j)
   {
     uns_char_sum += *array_uchar;
-    array_uchar+=j*sizeof(array_uchar);
+    array_uchar += j * sizeof (array_uchar);
   }
 
   return uns_char_sum;

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-lbu-compile-3.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-lbu-compile-3.c
@@ -10,7 +10,7 @@
 int
 fooQIunsigned (unsigned char* array_uchar, int i, int j)
 {
-  return array_uchar[i+j];
+  return array_uchar [i + j];
 }
 
 /* { dg-final { scan-assembler-times "cv\\.lbu\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\(\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\)" 1 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-lh-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-lh-compile-1.c
@@ -8,14 +8,12 @@
  */
 
 int
-fooHIsigned (signed short int* array_short, int n)
+fooHIsigned (signed short int* array_short)
 {
   int short_sum = 1;
 
-  for(int i=0; i<n; i++)
-  {
-    short_sum += array_short[i];
-  }
+  for (int i = 0; i < 200; i++)
+    short_sum += array_short [i];
 
   return short_sum;
 }

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-lh-compile-2.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-lh-compile-2.c
@@ -1,21 +1,21 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_mem } */
 /* { dg-options "-march=rv32i_xcvmem -mabi=ilp32 -fno-unroll-loops" } */
-/* { dg-skip-if "" { *-*-* } { "-O0" "-Os" "-Oz" "-Og" } } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-Og" } } */
 
 /*
  * Test for post-inc register-register loads.
  */
 
 int
-fooHIsigned (signed short int* array_short, int n, int j)
+fooHIsigned (signed short int* array_short, int j)
 {
   int short_sum = 1;
 
-  for(int i=0; i<n; i+=j)
+  for (int i = 0; i < 200; i += j)
   {
     short_sum += *array_short;
-    array_short+=j*sizeof(array_short);
+    array_short += j * sizeof (array_short);
   }
 
   return short_sum;

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-lh-compile-3.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-lh-compile-3.c
@@ -10,7 +10,7 @@
 int
 fooHIsigned (signed short int* array_short, int i, int j)
 {
-  return array_short[i+j];
+  return array_short [i + j];
 }
 
 /* { dg-final { scan-assembler-times "cv\\.lh\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\(\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\)" 1 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-lhu-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-lhu-compile-1.c
@@ -8,14 +8,12 @@
  */
 
 int
-fooHIunsigned (unsigned short int* array_ushort, int n)
+fooHIunsigned (unsigned short int* array_ushort)
 {
   int uns_short_sum = 1;
 
-  for(int i=0; i<n; i++)
-  {
-    uns_short_sum += array_ushort[i];
-  }
+  for (int i = 0; i < 200; i++)
+    uns_short_sum += array_ushort [i];
 
   return uns_short_sum;
 }

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-lhu-compile-2.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-lhu-compile-2.c
@@ -1,21 +1,21 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_mem } */
 /* { dg-options "-march=rv32i_xcvmem -mabi=ilp32 -fno-unroll-loops" } */
-/* { dg-skip-if "" { *-*-* } { "-O0" "-Os" "-Oz" "-Og" } } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-Og" } } */
 
 /*
  * Test for post-inc register-register loads.
  */
 
 int
-fooHIunsigned (unsigned short int* array_ushort, int n, int j)
+fooHIunsigned (unsigned short int* array_ushort, int j)
 {
   int uns_short_sum = 1;
 
-  for(int i=0; i<n; i+=j)
+  for (int i = 0; i < 200; i += j)
   {
     uns_short_sum += *array_ushort;
-    array_ushort+=j*sizeof(array_ushort);
+    array_ushort += j * sizeof (array_ushort);
   }
 
   return uns_short_sum;

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-lhu-compile-3.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-lhu-compile-3.c
@@ -10,7 +10,7 @@
 int
 fooHIunsigned (unsigned short int* array_ushort, int i, int j)
 {
-  return array_ushort[i+j];
+  return array_ushort [i + j];
 }
 
 /* { dg-final { scan-assembler-times "cv\\.lhu\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\(\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\)" 1 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-lw-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-lw-compile-1.c
@@ -1,36 +1,31 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_mem } */
-/* { dg-options "-march=rv32i_xcvmem -mabi=ilp32 -fno-unroll-loops" } */
-/* We don't generate for some optimization levels. TODO: should support for Os,
-   Oz and Og */
-/* { dg-skip-if "" { *-*-* }  { "-O0" "-Os" "-Oz" "-Og" } { "" } } */
+/* { dg-options "-march=rv32ic_xcvmem -mabi=ilp32 -fno-unroll-loops" } */
+/* We don't generate for some optimization levels. TODO: should support for Og. */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-Og" } } */
 
 /*
  * Test for post-inc register-immediate loads.
  */
 
 int
-fooSIsigned (signed int* array_int, int n)
+fooSIsigned (signed int* array_int)
 {
   int int_sum = 1;
 
-  for(int i=0; i<n; i++)
-  {
-    int_sum += array_int[i];
-  }
+  for (int i = 0; i < 200; i++)
+    int_sum += array_int [i];
 
   return int_sum;
 }
 
 int
-fooSIunsigned (unsigned int* array_uint, int n)
+fooSIunsigned (unsigned int* array_uint)
 {
   int uns_int_sum = 1;
 
-  for(int i=0; i<n; i++)
-  {
-    uns_int_sum += array_uint[i];
-  }
+  for (int i = 0; i < 200; i++)
+    uns_int_sum += array_uint [i];
 
   return uns_int_sum;
 }

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-lw-compile-2.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-lw-compile-2.c
@@ -1,35 +1,35 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_mem } */
 /* { dg-options "-march=rv32i_xcvmem -mabi=ilp32 -fno-unroll-loops" } */
-/* { dg-skip-if "" { *-*-* } { "-O0" "-Os" "-Oz" "-Og" } } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-Og" } } */
 
 /*
  * Test for post-inc register-register loads.
  */
 
 int
-fooSIsigned (signed int* array_int, int n, int j)
+fooSIsigned (signed int* array_int, int j)
 {
   int int_sum = 1;
 
-  for(int i=0; i<n; i+=j)
+  for (int i = 0; i < 200; i += j)
   {
     int_sum += *array_int;
-    array_int+=j*sizeof(array_int);
+    array_int += j * sizeof (array_int);
   }
 
   return int_sum;
 }
 
 int
-fooSIunsigned (unsigned int* array_uint, int n, int j)
+fooSIunsigned (unsigned int* array_uint, int j)
 {
   int uns_int_sum = 1;
 
-  for(int i=0; i<n; i+=j)
+  for (int i = 0; i < 200; i += j)
   {
     uns_int_sum += *array_uint;
-    array_uint+=j*sizeof(array_uint);
+    array_uint += j * sizeof (array_uint);
   }
 
   return uns_int_sum;

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-lw-compile-3.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-lw-compile-3.c
@@ -10,13 +10,13 @@
 int
 fooSIsigned (signed int* array_int, int i, int j)
 {
-  return array_int[i+j];
+  return array_int [i + j];
 }
 
 int
 fooSIunsigned (unsigned int* array_uint, int i, int j)
 {
-  return array_uint[i+j];
+  return array_uint [i + j];
 }
 
 /* { dg-final { scan-assembler-times "cv\\.lw\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\(\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\)\\)" 2 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-sb-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-sb-compile-1.c
@@ -12,10 +12,8 @@ fooQIsigned (signed char* array_char, int n)
 {
   int char_sum = 1;
 
-  for(int i=0; i<n; i++)
-  {
-    array_char[i] += char_sum;
-  }
+  for (int i = 0; i < n; i++)
+    array_char [i] += char_sum;
 
   return char_sum;
 }
@@ -25,10 +23,8 @@ fooQIunsigned (unsigned char* array_uchar, int n)
 {
   int uns_char_sum = 1;
 
-  for(int i=0; i<n; i++)
-  {
-    array_uchar[i] += uns_char_sum;
-  }
+  for (int i = 0; i < n; i++)
+    array_uchar [i] += uns_char_sum;
 
   return uns_char_sum;
 }

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-sb-compile-2.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-sb-compile-2.c
@@ -12,10 +12,10 @@ fooQIsigned (signed char* array_char, int n, int j)
 {
   int char_sum = 1;
 
-  for(int i=0; i<n; i+=j)
+  for (int i = 0; i < n; i += j)
   {
     *array_char += char_sum;
-    array_char+=j*sizeof(array_char);
+    array_char += j * sizeof (array_char);
   }
 
   return char_sum;
@@ -26,10 +26,10 @@ fooQIunsigned (unsigned char* array_uchar, int n, int j)
 {
   int uns_char_sum = 1;
 
-  for(int i=0; i<n; i+=j)
+  for (int i = 0; i < n; i += j)
   {
     *array_uchar += uns_char_sum;
-    array_uchar+=j*sizeof(array_uchar);
+    array_uchar += j * sizeof (array_uchar);
   }
 
   return uns_char_sum;

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-sb-compile-3.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-sb-compile-3.c
@@ -12,7 +12,7 @@ fooQIsigned (signed char* array_char, int i, int j)
 {
   int char_sum = 1;
 
-  array_char[i+j] += char_sum;
+  array_char [i + j] += char_sum;
 
   return char_sum;
 }
@@ -22,7 +22,7 @@ fooQIunsigned (unsigned char* array_uchar, int i, int j)
 {
   int uns_char_sum = 1;
 
-  array_uchar[i+j] += uns_char_sum;
+  array_uchar [i + j] += uns_char_sum;
 
   return uns_char_sum;
 }

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-sh-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-sh-compile-1.c
@@ -1,34 +1,30 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_mem } */
 /* { dg-options "-march=rv32i_xcvmem -mabi=ilp32 -fno-unroll-loops" } */
-/* { dg-skip-if "" { *-*-* } { "-O0" "-Os" "-Oz" "-Og" } } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-Og" } } */
 
 /*
  * Test for post-inc register-immediate saves.
  */
 
 int
-fooHIsigned (signed short int* array_short, int n)
+fooHIsigned (signed short int* array_short)
 {
   int short_sum = 1;
 
-  for(int i=0; i<n; i++)
-  {
-    array_short[i] += short_sum;
-  }
+  for (int i = 0; i < 200; i++)
+    array_short [i] += short_sum;
 
   return short_sum;
 }
 
 int
-fooHIunsigned (unsigned short int* array_ushort, int n)
+fooHIunsigned (unsigned short int* array_ushort)
 {
   int uns_short_sum = 1;
 
-  for(int i=0; i<n; i++)
-  {
-    array_ushort[i] += uns_short_sum;
-  }
+  for (int i = 0; i < 200; i++)
+    array_ushort [i] += uns_short_sum;
 
   return uns_short_sum;
 }

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-sh-compile-2.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-sh-compile-2.c
@@ -1,35 +1,35 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_mem } */
 /* { dg-options "-march=rv32i_xcvmem -mabi=ilp32 -fno-unroll-loops" } */
-/* { dg-skip-if "" { *-*-* } { "-O0" "-Os" "-Oz" "-Og" } } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-Og" } } */
 
 /*
  * Test for post-inc register-register saves.
  */
 
 int
-fooHIsigned (signed short int* array_short, int n, int j)
+fooHIsigned (signed short int* array_short, int j)
 {
   int short_sum = 1;
 
-  for(int i=0; i<n; i+=j)
+  for (int i = 0; i < 200; i += j)
   {
     *array_short += short_sum;
-    array_short+=j*sizeof(array_short);
+    array_short += j * sizeof (array_short);
   }
 
   return short_sum;
 }
 
 int
-fooHIunsigned (unsigned short int* array_ushort, int n, int j)
+fooHIunsigned (unsigned short int* array_ushort, int j)
 {
   int uns_short_sum = 1;
 
-  for(int i=0; i<n; i+=j)
+  for (int i = 0; i < 200; i += j)
   {
     *array_ushort += uns_short_sum;
-    array_ushort+=j*sizeof(array_ushort);
+    array_ushort += j * sizeof (array_ushort);
   }
 
   return uns_short_sum;

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-sh-compile-3.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-sh-compile-3.c
@@ -12,7 +12,7 @@ fooHIsigned (signed short int* array_short, int i, int j)
 {
   int short_sum = 1;
 
-  array_short[i+j] = short_sum;
+  array_short [i + j] = short_sum;
 
   return short_sum;
 }
@@ -22,7 +22,7 @@ fooHIunsigned (unsigned short int* array_ushort, int i, int j)
 {
   int uns_short_sum = 1;
 
-  array_ushort[i+j] += uns_short_sum;
+  array_ushort [i + j] += uns_short_sum;
 
   return uns_short_sum;
 }

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-sw-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-sw-compile-1.c
@@ -1,34 +1,30 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_mem } */
 /* { dg-options "-march=rv32i_xcvmem -mabi=ilp32 -fno-unroll-loops" } */
-/* { dg-skip-if "" { *-*-* } { "-O0" "-Os" "-Oz" "-Og" } } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-Og" } } */
 
 /*
  * Test for post-inc register-immediate saves.
  */
 
 int
-fooSIsigned (signed int* array_int, int n)
+fooSIsigned (signed int* array_int)
 {
   int int_sum = 1;
 
-  for(int i=0; i<n; i++)
-  {
-    array_int[i] += int_sum;
-  }
+  for (int i = 0; i < 200; i++)
+    array_int [i] += int_sum;
 
   return int_sum;
 }
 
 int
-fooSIunsigned (unsigned int* array_uint, int n)
+fooSIunsigned (unsigned int* array_uint)
 {
   int uns_int_sum = 1;
 
-  for(int i=0; i<n; i++)
-  {
-    array_uint[i] += uns_int_sum;
-  }
+  for (int i = 0; i < 200; i++)
+    array_uint [i] += uns_int_sum;
 
   return uns_int_sum;
 }

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-sw-compile-2.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-sw-compile-2.c
@@ -1,35 +1,35 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target cv_mem } */
 /* { dg-options "-march=rv32i_xcvmem -mabi=ilp32 -fno-unroll-loops" } */
-/* { dg-skip-if "" { *-*-* } { "-O0" "-Os" "-Oz" "-Og" } } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-Og" } } */
 
 /*
  * Test for post-inc register-register saves.
  */
 
 int
-fooSIsigned (signed int* array_int, int n, int j)
+fooSIsigned (signed int* array_int, int j)
 {
   int int_sum = 1;
 
-  for(int i=0; i<n; i+=j)
+  for (int i = 0; i < 200; i += j)
   {
     *array_int += int_sum;
-    array_int+=j*sizeof(array_int);
+    array_int += j * sizeof (array_int);
   }
 
   return int_sum;
 }
 
 int
-fooSIunsigned (unsigned int* array_uint, int n, int j)
+fooSIunsigned (unsigned int* array_uint, int j)
 {
   int uns_int_sum = 1;
 
-  for(int i=0; i<n; i+=j)
+  for (int i = 0; i < 200; i += j)
   {
     *array_uint += uns_int_sum;
-    array_uint+=j*sizeof(array_uint);
+    array_uint += j * sizeof (array_uint);
   }
 
   return uns_int_sum;

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-sw-compile-3.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-sw-compile-3.c
@@ -12,7 +12,7 @@ fooSIsigned (signed int* array_int, int i, int j)
 {
   int int_sum = 1;
 
-  array_int[i+j] = int_sum;
+  array_int [i + j] = int_sum;
 
   return int_sum;
 }
@@ -22,7 +22,7 @@ fooSIunsigned (unsigned int* array_uint, int i, int j)
 {
   int uns_int_sum = 1;
 
-  array_uint[i+j] = uns_int_sum;
+  array_uint [i + j] = uns_int_sum;
 
   return uns_int_sum;
 }


### PR DESCRIPTION
Partial fix for issue #58 and tidy up

6 tests still require Os or Oz.
16 tests require Og.

Files Changed:

  * cv-mem-lb-compile-1.c
  * cv-mem-lb-compile-2.c
  * cv-mem-lb-compile-3.c
  * cv-mem-lbu-compile-1.c
  * cv-mem-lbu-compile-2.c
  * cv-mem-lbu-compile-3.c
  * cv-mem-lh-compile-1.c
  * cv-mem-lh-compile-2.c
  * cv-mem-lh-compile-3.c
  * cv-mem-lhu-compile-1.c
  * cv-mem-lhu-compile-2.c
  * cv-mem-lhu-compile-3.c
  * cv-mem-lw-compile-1.c
  * cv-mem-lw-compile-2.c
  * cv-mem-lw-compile-3.c
  * cv-mem-sb-compile-1.c
  * cv-mem-sb-compile-2.c
  * cv-mem-sb-compile-3.c
  * cv-mem-sh-compile-1.c
  * cv-mem-sh-compile-2.c
  * cv-mem-sh-compile-3.c
  * cv-mem-sw-compile-1.c
  * cv-mem-sw-compile-2.c
  * cv-mem-sw-compile-3.c

Thanks for taking the time to contribute to GCC! Please be advised that if you are
viewing this on `github.com`, that the mirror there is unofficial and unmonitored.
The GCC community does not use `github.com` for their contributions. Instead, we use
a mailing list (`gcc-patches@gcc.gnu.org`) for code submissions, code reviews, and
bug reports. Please send patches there instead.
