### PR TITLE
Add header file for XCVelw

### DIFF
--- a/gcc/config.gcc
+++ b/gcc/config.gcc
@@ -549,7 +549,7 @@ riscv*)
 	extra_objs="${extra_objs} riscv-vector-builtins.o riscv-vector-builtins-shapes.o riscv-vector-builtins-bases.o"
 	extra_objs="${extra_objs} thead.o riscv-target-attr.o corev.o"
 	d_target_objs="riscv-d.o"
-	extra_headers="riscv_vector.h riscv_corev_alu.h"
+	extra_headers="riscv_vector.h riscv_corev_alu.h riscv_corev_elw.h"
 	target_gtfiles="$target_gtfiles \$(srcdir)/config/riscv/riscv-vector-builtins.cc"
 	target_gtfiles="$target_gtfiles \$(srcdir)/config/riscv/riscv-vector-builtins.h"
 	;;

--- a/gcc/config/riscv/riscv_corev_elw.h
+++ b/gcc/config/riscv/riscv_corev_elw.h
@@ -1,0 +1,44 @@
+/* riscv_corev_elw.h - CORE-V ELW intrinsics
+   Copyright (C) 2022-2024 Free Software Foundation, Inc.
+
+   This file is part of GCC.
+
+   GCC is free software; you can redistribute it and/or modify it
+   under the terms of the GNU General Public License as published
+   by the Free Software Foundation; either version 3, or (at your
+   option) any later version.
+
+   GCC is distributed in the hope that it will be useful, but WITHOUT
+   ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+   or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+   License for more details.
+
+   Under Section 7 of GPL version 3, you are granted additional
+   permissions described in the GCC Runtime Library Exception, version
+   3.1, as published by the Free Software Foundation.
+
+   You should have received a copy of the GNU General Public License and
+   a copy of the GCC Runtime Library Exception along with this program;
+   see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+   <http://www.gnu.org/licenses/>.  */
+
+#ifndef __RISCV_COREV_ELW_H
+#define __RISCV_COREV_ELW_H
+
+#include <stdint.h>
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+#if defined(__riscv_xcvelw)
+
+#define __riscv_cv_elw_elw(loc) __builtin_riscv_cv_elw_elw(loc)
+
+#endif // defined(__riscv_xcvelw)
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif // define __RISCV_COREV_ELW_H

--- a/gcc/testsuite/gcc.target/riscv/elw-c-api.c
+++ b/gcc/testsuite/gcc.target/riscv/elw-c-api.c
@@ -1,0 +1,12 @@
+/* { dg-do compile } */
+/* { dg-require-effective-target cv_elw } */
+/* { dg-options "-march=rv32i_xcvelw -mabi=ilp32" } */
+
+#include <stdint.h>
+#include <riscv_corev_elw.h>
+
+uint32_t
+test_elw (void *a)
+{
+  return __riscv_cv_elw_elw (a);
+}


### PR DESCRIPTION
Files Changed:
  * gcc/config.gcc: Add header file.
  * gcc/config/riscv/riscv_corev_elw.h: Likewise.
  * gcc/testsuite/gcc.target/riscv/elw-c-api.c: New Test.
