### PR TITLE
Add header file for XCVbitmanip

### DIFF
--- a/gcc/config.gcc
+++ b/gcc/config.gcc
@@ -549,7 +549,7 @@ riscv*)
 	extra_objs="${extra_objs} riscv-vector-builtins.o riscv-vector-builtins-shapes.o riscv-vector-builtins-bases.o"
 	extra_objs="${extra_objs} thead.o riscv-target-attr.o corev.o"
 	d_target_objs="riscv-d.o"
-	extra_headers="riscv_vector.h riscv_corev_alu.h riscv_corev_elw.h riscv_corev_mac.h"
+	extra_headers="riscv_vector.h riscv_corev_alu.h riscv_corev_elw.h riscv_corev_mac.h riscv_corev_bitmanip.h"
 	target_gtfiles="$target_gtfiles \$(srcdir)/config/riscv/riscv-vector-builtins.cc"
 	target_gtfiles="$target_gtfiles \$(srcdir)/config/riscv/riscv-vector-builtins.h"
 	;;

--- a/gcc/config/riscv/corev.md
+++ b/gcc/config/riscv/corev.md
@@ -1054,10 +1054,7 @@
 
 (define_insn "riscv_cv_bitmanip_clb"
   [(set (match_operand:QI 0 "register_operand" "=r")
-        (if_then_else (eq:SI (match_operand:SI 1 "register_operand" "r") (const_int 0))
-                      (const_int 0)
-                      (clrsb:QI (match_dup 1))))]
-
+	(truncate:QI (clrsb:SI (match_operand:SI 1 "register_operand" "r"))))]
   "TARGET_XCVBITMANIP && !TARGET_64BIT"
   "cv.clb\t%0,%1"
   [(set_attr "type" "bitmanip")

--- a/gcc/config/riscv/riscv_corev_bitmanip.h
+++ b/gcc/config/riscv/riscv_corev_bitmanip.h
@@ -1,0 +1,57 @@
+/* riscv_corev_bitmanip.h - CORE-V BITMANIP intrinsics
+   Copyright (C) 2022-2023 Free Software Foundation, Inc.
+
+   This file is part of GCC.
+
+   GCC is free software; you can redistribute it and/or modify it
+   under the terms of the GNU General Public License as published
+   by the Free Software Foundation; either version 3, or (at your
+   option) any later version.
+
+   GCC is distributed in the hope that it will be useful, but WITHOUT
+   ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+   or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+   License for more details.
+
+   Under Section 7 of GPL version 3, you are granted additional
+   permissions described in the GCC Runtime Library Exception, version
+   3.1, as published by the Free Software Foundation.
+
+   You should have received a copy of the GNU General Public License and
+   a copy of the GCC Runtime Library Exception along with this program;
+   see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+   <http://www.gnu.org/licenses/>.  */
+
+#ifndef __RISCV_COREV_BITMANIP_H
+#define __RISCV_COREV_BITMANIP_H
+
+#include <stdint.h>
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+#if defined(__riscv_xcvbitmanip)
+
+#define __riscv_cv_bitmanip_extract(a, range) __builtin_riscv_cv_bitmanip_extract(a, range)
+#define __riscv_cv_bitmanip_extractu(a, range) __builtin_riscv_cv_bitmanip_extractu(a, range)
+#define __riscv_cv_bitmanip_insert(a, range, k) __builtin_riscv_cv_bitmanip_insert(a, range, k)
+#define __riscv_cv_bitmanip_bclr(a, range) __builtin_riscv_cv_bitmanip_bclr(a, range)
+#define __riscv_cv_bitmanip_bset(a, range) __builtin_riscv_cv_bitmanip_bset(a, range)
+#define __riscv_cv_bitmanip_ff1(a) __builtin_riscv_cv_bitmanip_ff1(a)
+#define __riscv_cv_bitmanip_fl1(a) __builtin_riscv_cv_bitmanip_fl1(a)
+#define __riscv_cv_bitmanip_clb(a) __builtin_riscv_cv_bitmanip_clb(a)
+#define __riscv_cv_bitmanip_cnt(a) __builtin_riscv_cv_bitmanip_cnt(a)
+#define __riscv_cv_bitmanip_ror(a, b) __builtin_riscv_cv_bitmanip_ror(a, b)
+
+#define __riscv_cv_bitmanip_bitrev(rs1, PTS, RADIX) \
+  (unsigned long) __builtin_riscv_cv_bitmanip_bitrev((unsigned long) (rs1), \
+                                 (const uint8_t) (PTS), (const uint8_t) (RADIX))
+
+#endif // defined(__riscv_xcvbitmanip)
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif // define __RISCV_COREV_BITMANIP_H

--- a/gcc/testsuite/gcc.target/riscv/bitmanip-c-api.c
+++ b/gcc/testsuite/gcc.target/riscv/bitmanip-c-api.c
@@ -1,0 +1,102 @@
+/* { dg-do compile } */
+/* { dg-require-effective-target cv_bitmanip } */
+/* { dg-options "-march=rv32i_xcvbitmanip -mabi=ilp32" } */
+
+#include <stdint.h>
+#include <riscv_corev_bitmanip.h>
+
+uint32_t
+test_extract (uint32_t a)
+{
+  return __riscv_cv_bitmanip_extract (a, 0);
+}
+
+uint32_t
+test_extractr (uint32_t a, uint16_t b)
+{
+  return __riscv_cv_bitmanip_extract (a, b);
+}
+
+uint32_t 
+test_extractu (uint32_t a)
+{
+  return __riscv_cv_bitmanip_extractu (a, 0);
+}
+
+uint32_t 
+test_extractur (uint32_t a, uint16_t b)
+{
+  return __riscv_cv_bitmanip_extractu (a, b);
+}
+
+uint32_t 
+test_insert (uint32_t a, uint32_t c)
+{
+  return __riscv_cv_bitmanip_insert (a, 0, c);
+}
+
+uint32_t 
+test_insertr (uint32_t a, uint16_t b, uint32_t c)
+{
+  return __riscv_cv_bitmanip_insert (a, b, c);
+}
+
+uint32_t 
+test_bclr (uint32_t a)
+{
+  return __riscv_cv_bitmanip_bclr (a, 0);
+}
+
+uint32_t 
+test_bclrr (uint32_t a, uint16_t b)
+{
+  return __riscv_cv_bitmanip_bclr (a, b);
+}
+
+uint32_t 
+test_bset (uint32_t a)
+{
+  return __riscv_cv_bitmanip_bset (a, 0);
+}
+
+uint32_t 
+test_bsetr (uint32_t a, uint16_t b)
+{
+  return __riscv_cv_bitmanip_bclr (a, b);
+}
+
+uint32_t 
+test_ff1 (uint32_t a)
+{
+  return __riscv_cv_bitmanip_ff1 (a);
+}
+
+uint32_t 
+test_fl1 (uint32_t a)
+{
+  return __riscv_cv_bitmanip_fl1 (a);
+}
+
+uint32_t 
+test_clb (uint32_t a)
+{
+  return __riscv_cv_bitmanip_clb (a);
+}
+
+uint32_t 
+test_cnt (uint32_t a)
+{
+  return __riscv_cv_bitmanip_cnt (a);
+}
+
+uint32_t 
+test_ror (uint32_t a, uint32_t b)
+{
+  return __riscv_cv_bitmanip_ror (a, b);
+}
+
+uint32_t
+test_bitrev (uint32_t a)
+{
+  return __riscv_cv_bitmanip_bitrev (a, 1, 2);
+}


### PR DESCRIPTION
Files Changed:
  * gcc/config.gcc: Add header file.
  * gcc/config/riscv/riscv_corev_bitmanip.h: Likewise.
  * gcc/testsuite/gcc.target/riscv/bitmanip-c-api.c: New Test.
  * config/riscv/corev.md: Update RTL for cv.ff1 and cv.clb.
