### PR TITLE
RISC-V: Fix XCVALU extension patterns

### DIFF
--- a/gcc/config/riscv/corev.md
+++ b/gcc/config/riscv/corev.md
@@ -640,8 +640,7 @@
 (define_insn "riscv_cv_alu_exths"
   [(set (match_operand:SI 0 "register_operand" "=r")
    (sign_extend:SI
-     (truncate:HI
-       (match_operand:HI 1 "register_operand" "r"))))]
+     (match_operand:HI 1 "register_operand" "r")))]
 
   "TARGET_XCVALU && !TARGET_64BIT"
   "cv.exths\t%0, %1"
@@ -651,8 +650,7 @@
 (define_insn "riscv_cv_alu_exthz"
   [(set (match_operand:SI 0 "register_operand" "=r")
    (zero_extend:SI
-     (truncate:HI
-       (match_operand:HI 1 "register_operand" "r"))))]
+     (match_operand:HI 1 "register_operand" "r")))]
 
   "TARGET_XCVALU && !TARGET_64BIT"
   "cv.exthz\t%0, %1"
@@ -662,8 +660,7 @@
 (define_insn "riscv_cv_alu_extbs"
   [(set (match_operand:SI 0 "register_operand" "=r")
    (sign_extend:SI
-     (truncate:QI
-       (match_operand:QI 1 "register_operand" "r"))))]
+     (match_operand:QI 1 "register_operand" "r")))]
 
   "TARGET_XCVALU && !TARGET_64BIT"
   "cv.extbs\t%0, %1"
@@ -673,8 +670,7 @@
 (define_insn "riscv_cv_alu_extbz"
   [(set (match_operand:SI 0 "register_operand" "=r")
    (zero_extend:SI
-     (truncate:QI
-   (match_operand:QI 1 "register_operand" "r"))))]
+     (match_operand:QI 1 "register_operand" "r")))]
 
   "TARGET_XCVALU && !TARGET_64BIT"
   "cv.extbz\t%0, %1"
@@ -3062,7 +3058,8 @@
    l<SHORT:size>\t%0,%1"
   "&& reload_completed
    && REG_P (operands[1])
-   && !paradoxical_subreg_p (operands[0])"
+   && !paradoxical_subreg_p (operands[0])
+   && !(TARGET_XCVALU && !TARGET_64BIT)"
   [(set (match_dup 0) (ashift:SI (match_dup 1) (match_dup 2)))
    (set (match_dup 0) (ashiftrt:SI (match_dup 0) (match_dup 2)))]
 {


### PR DESCRIPTION
Remove redundant truncate operations from the XCVALU sign- and zero-extension patterns.  The input operands already have the proper QI or HI mode, so the truncate expressions are unnecessary and make the RTL pattern less canonical.

Also prevent the generic SI sign-extension split from being used for XCVALU on RV32, where dedicated cv.ext* instructions are available.

gcc/ChangeLog:

	* config/riscv/riscv.md (riscv_cv_alu_exths): Remove redundant truncate. (riscv_cv_alu_exthz): Likewise. (riscv_cv_alu_extbs): Likewise. (riscv_cv_alu_extbz): Likewise. (*extend<SHORT:mode><SUPERQI:mode>2): Disable split for XCVALU on RV32.

Thanks for taking the time to contribute to GCC! Please be advised that if you are
viewing this on `github.com`, that the mirror there is unofficial and unmonitored.
The GCC community does not use `github.com` for their contributions. Instead, we use
a mailing list (`gcc-patches@gcc.gnu.org`) for code submissions, code reviews, and
bug reports. Please send patches there instead.
