### PR TITLE
RISC-V: Fix CORE-V effective-target ABI options

### DIFF
--- a/gcc/testsuite/lib/target-supports.exp
+++ b/gcc/testsuite/lib/target-supports.exp
@@ -13376,7 +13376,7 @@ proc check_effective_target_cv_mac { } {
         {
           asm ("cv.mac t0, t1, t2");
         }
-    } "-march=rv32i_xcvmac" ]
+    } "-march=rv32i_xcvmac -mabi=ilp32" ]
 }
 
 # Return 1 if the CORE-V ALU extension is available.
@@ -13389,7 +13389,7 @@ proc check_effective_target_cv_alu { } {
         {
           asm ("cv.addn t0, t1, t2, 0");
         }
-    } "-march=rv32i_xcvalu" ]
+    } "-march=rv32i_xcvalu -mabi=ilp32" ]
 }
 
 # Return 1 if the CORE-V ELW extension is available.
@@ -13402,7 +13402,7 @@ proc check_effective_target_cv_elw { } {
         {
           asm ("cv.elw x0, 0(x0)");
         }
-    } "-march=rv32i_xcvelw" ]
+    } "-march=rv32i_xcvelw -mabi=ilp32" ]
 }
 
 # Return 1 if the CORE-V SIMD extension is available.
@@ -13415,7 +13415,7 @@ proc check_effective_target_cv_simd { } {
         {
           asm ("cv.add.sc.b x0, x0, x0");
         }
-    } "-march=rv32i_xcvsimd" ]
+    } "-march=rv32i_xcvsimd -mabi=ilp32" ]
 }
 
 # Return 1 if the CORE-V BI extension is available
@@ -13428,7 +13428,7 @@ proc check_effective_target_cv_bi { } {
         {
           asm ("cv.beqimm t0, -16, foo");
         }
-    } "-march=rv32i_xcvbi" ]
+    } "-march=rv32i_xcvbi -mabi=ilp32" ]
 }
 
 # Return 1 if the CORE-V BITMANIP extension is available.
@@ -13441,7 +13441,7 @@ proc check_effective_target_cv_bitmanip { } {
         {
           asm ("cv.extract t0, t1, 20, 20");
         }
-    } "-march=rv32i_xcvbitmanip" ]
+    } "-march=rv32i_xcvbitmanip -mabi=ilp32" ]
 }
 
 # Return 1 if the CORE-V MEM extension is available.
@@ -13454,7 +13454,7 @@ proc check_effective_target_cv_mem { } {
         {
           asm ("cv.lw t0, (t1), 4");
         }
-    } "-march=rv32i_xcvmem" ]
+    } "-march=rv32i_xcvmem -mabi=ilp32" ]
 }
 
 proc check_effective_target_loongarch_sx { } {


### PR DESCRIPTION
Add -mabi=ilp32 to the CORE-V effective-target checks in target-supports.exp.

These checks use RV32 -march options, so they should also pass the matching ILP32 ABI option.  This allows the checks to compile correctly and prevents CORE-V tests from being reported as unsupported.

gcc/testsuite/ChangeLog:

	* lib/target-supports.exp (check_effective_target_cv_mac): Add -mabi=ilp32. (check_effective_target_cv_alu): Likewise. (check_effective_target_cv_elw): Likewise. (check_effective_target_cv_simd): Likewise. (check_effective_target_cv_bi): Likewise. (check_effective_target_cv_bitmanip): Likewise. (check_effective_target_cv_mem): Likewise.

Thanks for taking the time to contribute to GCC! Please be advised that if you are
viewing this on `github.com`, that the mirror there is unofficial and unmonitored.
The GCC community does not use `github.com` for their contributions. Instead, we use
a mailing list (`gcc-patches@gcc.gnu.org`) for code submissions, code reviews, and
bug reports. Please send patches there instead.
