### PR TITLE
RISCV: Add post-increment addressing support for Xcvmem

### DIFF
--- a/gcc/config/riscv/riscv.cc
+++ b/gcc/config/riscv/riscv.cc
@@ -1317,7 +1317,7 @@ riscv_index_reg_class ()
 int
 riscv_regno_ok_for_index_p (int regno)
 {
-  if (TARGET_XTHEADMEMIDX || TARGET_XTHEADFMEMIDX)
+  if (TARGET_XTHEADMEMIDX || TARGET_XTHEADFMEMIDX || TARGET_XCVMEM)
     return riscv_regno_mode_ok_for_base_p (regno, VOIDmode, 1);
 
   return 0;
@@ -1615,6 +1615,12 @@ riscv_classify_address (struct riscv_address_info *info, rtx x,
       info->type = ADDRESS_REG;
       info->reg = x;
       info->offset = const0_rtx;
+      return riscv_valid_base_register_p (info->reg, mode, strict_p);
+
+    case POST_INC:
+      info->type = ADDRESS_REG_INC;
+      info->reg = XEXP (x, 0);
+      info->offset = const0_rtx; /* not used */
       return riscv_valid_base_register_p (info->reg, mode, strict_p);
 
     case POST_MODIFY:

--- a/gcc/config/riscv/riscv.h
+++ b/gcc/config/riscv/riscv.h
@@ -1256,6 +1256,14 @@ extern void riscv_remove_unneeded_save_restore_calls (void);
 
 #define HAVE_POST_MODIFY_REG TARGET_XCVMEM
 
+#define USE_LOAD_POST_INCREMENT(MODE)  \
+  (TARGET_XCVMEM && GET_MODE_SIZE (MODE).to_constant () <= 2047 \
+   ? 1 : HAVE_POST_INCREMENT)
+
+#define USE_STORE_POST_INCREMENT(MODE) \
+  (TARGET_XCVMEM && GET_MODE_SIZE (MODE).to_constant () <= 2047 \
+   ? 1 : HAVE_POST_INCREMENT)
+
 /* Check TLS Descriptors mechanism is selected.  */
 #define TARGET_TLSDESC (riscv_tls_dialect == TLS_DESCRIPTORS)
 

--- a/gcc/testsuite/gcc.target/riscv/cv-mem-post-inc-ivopts.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-mem-post-inc-ivopts.c
@@ -1,0 +1,41 @@
+/* { dg-do compile } */
+/* { dg-require-effective-target cv_mem } */
+/* { dg-options "-march=rv32ic_xcvmem -mabi=ilp32 -fno-unroll-loops" } */
+/* We don't generate for some optimization levels because:
+ * (1) O0 does not generate any post-increment pattern;
+ * (2) Og, Osm and Oz generate register-register patterns. */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-Og" "-Os" "-Oz"} } */
+/*
+ * Test that USE_LOAD_POST_INCREMENT / USE_STORE_POST_INCREMENT causes ivopts
+ * to prefer pointer IVs over integer-index IVs when two arrays are accessed
+ * in the same loop, resulting in post-increment loads AND stores rather than
+ * register-offset forms with a separate addi.
+ */
+void
+scale_si (int * __restrict__ dst, const int * __restrict__ src, int n, int k)
+{
+  for (int i = 0; i < n; i++)
+    dst[i] = src[i] * k;
+}
+
+void
+scale_hi (short * __restrict__ dst, const short * __restrict__ src, int n, short k)
+{
+  for (int i = 0; i < n; i++)
+    dst[i] = src[i] * k;
+}
+
+void
+scale_qi (signed char * __restrict__ dst, const signed char * __restrict__ src,
+          int n, signed char k)
+{
+  for (int i = 0; i < n; i++)
+    dst[i] = src[i] * k;
+}
+
+/* { dg-final { scan-assembler-times "cv\\.lw\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[0-11\]\),\\(\(\?\:t\[0-6\]\|a\[0-7\]\|s\[0-11\]\)\\),4" 1 } } */
+/* { dg-final { scan-assembler-times "cv\\.sw\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[0-11\]\),\\(\(\?\:t\[0-6\]\|a\[0-7\]\|s\[0-11\]\)\\),4" 1 } } */
+/* { dg-final { scan-assembler-times "cv\\.lh\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[0-11\]\),\\(\(\?\:t\[0-6\]\|a\[0-7\]\|s\[0-11\]\)\\),2" 1 } } */
+/* { dg-final { scan-assembler-times "cv\\.sh\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[0-11\]\),\\(\(\?\:t\[0-6\]\|a\[0-7\]\|s\[0-11\]\)\\),2" 1 } } */
+/* { dg-final { scan-assembler-times "cv\\.lb\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[0-11\]\),\\(\(\?\:t\[0-6\]\|a\[0-7\]\|s\[0-11\]\)\\),1" 1 } } */
+/* { dg-final { scan-assembler-times "cv\\.sb\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[0-11\]\),\\(\(\?\:t\[0-6\]\|a\[0-7\]\|s\[0-11\]\)\\),1" 1 } } */


### PR DESCRIPTION
Three changes added to guarantee the generation of CORE-V Xcvmem post-increment load/store instructions:

1. riscv_classify_address: add missing POST_INC case, classified as ADDRESS_REG_INC, so post-increment addresses are not rejected as illegitimate during reload/LRA and survive to instruction emission.

2. riscv_regno_ok_for_index_p: accept GP registers as index registers when TARGET_XCVMEM is active, consistent with XTHEADMEMIDX handling.

3. USE_LOAD_POST_INCREMENT / USE_STORE_POST_INCREMENT: inform ivopts that post-increment is cheap so it prefers pointer IVs over integer- index IVs in multi-array loops, eliminating redundant addi instructions. The mode size guard ensures the stride fits the 12-bit immediate field.

Without (1) and (2), auto-inc-dec combinations are rejected by reload. Without (3), single-array loops work but multi-array loops fall back to register-offset addressing with a separate addi for pointer advance.

gcc/ChangeLog:

	* config/riscv/riscv.cc (riscv_regno_ok_for_index_p): Enable index register support for TARGET_XCVMEM. (riscv_classify_address): Handle POST_INC as ADDRESS_REG_INC.
	* config/riscv/riscv.h (USE_LOAD_POST_INCREMENT): New macro. (USE_STORE_POST_INCREMENT): New macro.

gcc/testsuite/ChangeLog:

	* gcc.target/riscv/cv-mem-post-inc-ivopts.c: New test.

Thanks for taking the time to contribute to GCC! Please be advised that if you are
viewing this on `github.com`, that the mirror there is unofficial and unmonitored.
The GCC community does not use `github.com` for their contributions. Instead, we use
a mailing list (`gcc-patches@gcc.gnu.org`) for code submissions, code reviews, and
bug reports. Please send patches there instead.
